### PR TITLE
carbon energy tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,7 @@ feature_considerations.md
 
 # Pre-commit
 .pre-commit
+
+# Tester agent
+TESTER_AGENT.md
+tests/RESULTS.md

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ warpt power
 | `warpt stress` | Run stress tests across CPU, GPU, RAM, storage, and network |
 | `warpt monitor` | Real-time system monitoring with TUI dashboard |
 | `warpt power` | Power consumption monitoring and per-process attribution |
+| `warpt carbon` | Track energy consumption, CO2 emissions, and estimated cost |
 | `warpt benchmark` | Performance benchmarking suite |
 
 ## Documentation
@@ -59,6 +60,30 @@ warpt power
 | Windows | Limited support (see [Known Limitations](https://docs.earthframe.com/support_matrix#known-limitations)) |
 
 **GPU Support:** NVIDIA GPUs supported. AMD, Intel, and Apple Silicon GPU support coming soon.
+
+## Carbon Tracking
+
+warpt automatically tracks energy usage and CO2 emissions during stress tests and power monitoring. You can also track any workload manually:
+
+```bash
+# Automatic — built into stress tests
+warpt stress -c cpu -d 30
+# [carbon] 30.2s | 23.8W avg | 199.7 mWh | 0.08g CO2 | $0.0000 | less than breathing for a minute
+
+# Manual — track any workload
+warpt carbon start
+# ... run your workload ...
+warpt carbon stop
+
+# View history and totals
+warpt carbon history
+warpt carbon summary
+
+# Check available grid regions and carbon intensities
+warpt carbon regions
+```
+
+Carbon calculations use regional grid intensity data to estimate CO2 emissions from energy consumption. Configure your region with `--region` (defaults to US).
 
 ## Example Output
 
@@ -87,8 +112,9 @@ GPU Information:
 
 ## Alpha Release
 
-This is **v0.1.0-alpha**. Some features are still in development:
+This is an **alpha release**. Some features are still in development:
 
+- Carbon tracking — new in v0.2.0
 - AMD GPU support (ROCm) — in progress
 - Intel GPU support (oneAPI) — in progress
 - Apple Neural Engine — in progress

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "warpt"
-version = "0.1.2"
+version = "0.2.0"
 description = "Performance monitoring and system utilities"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -66,6 +66,7 @@ warpt = "warpt.cli:warpt"
 packages = [
     "warpt",
     "warpt.backends",
+    "warpt.carbon",
     "warpt.backends.hardware",
     "warpt.backends.hardware.storage",
     "warpt.backends.power",

--- a/tests/test_carbon_calculator.py
+++ b/tests/test_carbon_calculator.py
@@ -1,0 +1,122 @@
+"""Tests for carbon calculator module."""
+
+from warpt.carbon.calculator import CarbonCalculator
+from warpt.carbon.grid_intensity import GRID_INTENSITY, get_grid_intensity, list_regions
+
+
+class TestGridIntensity:
+    """Tests for grid intensity lookup."""
+
+    def test_known_region(self):
+        """Look up a known region."""
+        assert get_grid_intensity("US") == 390
+
+    def test_unknown_region_falls_back_to_world(self):
+        """Unknown region returns WORLD average."""
+        assert get_grid_intensity("XX") == GRID_INTENSITY["WORLD"]
+
+    def test_case_insensitive(self):
+        """Region lookup is case-insensitive."""
+        assert get_grid_intensity("us") == 390
+        assert get_grid_intensity("eu-fr") == 60
+
+    def test_list_regions_returns_all(self):
+        """List all regions."""
+        regions = list_regions()
+        assert "US" in regions
+        assert "WORLD" in regions
+        assert len(regions) == len(GRID_INTENSITY)
+
+
+class TestCarbonCalculator:
+    """Tests for CarbonCalculator energy/CO2/cost math."""
+
+    def test_energy_from_samples_empty(self):
+        """Empty samples return 0."""
+        calc = CarbonCalculator(region="US")
+        assert calc.energy_from_samples([]) == 0.0
+
+    def test_energy_from_samples_single(self):
+        """Single sample returns 0 (need at least 2 for integration)."""
+        calc = CarbonCalculator(region="US")
+        assert calc.energy_from_samples([(0.0, 100.0)]) == 0.0
+
+    def test_energy_from_samples_constant_power(self):
+        """100W for 3600s = 0.1 kWh."""
+        calc = CarbonCalculator(region="US")
+        samples = [(0.0, 100.0), (3600.0, 100.0)]
+        energy = calc.energy_from_samples(samples)
+        assert abs(energy - 0.1) < 1e-9
+
+    def test_energy_from_samples_trapezoidal(self):
+        """Linear ramp from 0W to 200W over 3600s = 0.1 kWh."""
+        calc = CarbonCalculator(region="US")
+        samples = [(0.0, 0.0), (3600.0, 200.0)]
+        energy = calc.energy_from_samples(samples)
+        assert abs(energy - 0.1) < 1e-9
+
+    def test_energy_from_samples_multiple_points(self):
+        """Test multi-segment trapezoidal integration."""
+        calc = CarbonCalculator(region="US")
+        samples = [
+            (0.0, 100.0),
+            (1800.0, 100.0),
+            (1800.0, 200.0),
+            (3600.0, 200.0),
+        ]
+        energy = calc.energy_from_samples(samples)
+        # Seg 1: (100+100)/2 * 1800 = 180000 J
+        # Seg 2: (100+200)/2 * 0 = 0 J
+        # Seg 3: (200+200)/2 * 1800 = 360000 J
+        # Total: 540000 J = 0.15 kWh
+        assert abs(energy - 0.15) < 1e-9
+
+    def test_energy_negative_time_gap_ignored(self):
+        """Negative time deltas contribute 0 energy."""
+        calc = CarbonCalculator(region="US")
+        samples = [(100.0, 50.0), (50.0, 50.0)]
+        energy = calc.energy_from_samples(samples)
+        assert energy == 0.0
+
+    def test_co2_from_energy(self):
+        """US grid: 390 gCO2/kWh * 1 kWh = 390g."""
+        calc = CarbonCalculator(region="US")
+        assert abs(calc.co2_from_energy(1.0) - 390.0) < 1e-9
+
+    def test_co2_from_energy_france(self):
+        """France: 60 gCO2/kWh * 1 kWh = 60g."""
+        calc = CarbonCalculator(region="EU-FR")
+        assert abs(calc.co2_from_energy(1.0) - 60.0) < 1e-9
+
+    def test_cost_from_energy_default_rate(self):
+        """1 kWh * $0.12 = $0.12."""
+        calc = CarbonCalculator(region="US")
+        assert abs(calc.cost_from_energy(1.0) - 0.12) < 1e-9
+
+    def test_cost_from_energy_custom_rate(self):
+        """1 kWh * $0.25 = $0.25."""
+        calc = CarbonCalculator(region="US")
+        assert abs(calc.cost_from_energy(1.0, rate=0.25) - 0.25) < 1e-9
+
+    def test_humanize_tiny(self):
+        """Sub-gram CO2 returns breathing comparison."""
+        calc = CarbonCalculator(region="US")
+        assert "breathing" in calc.humanize(0.5)
+
+    def test_humanize_phone(self):
+        """Small CO2 returns phone charging comparison."""
+        calc = CarbonCalculator(region="US")
+        result = calc.humanize(20.0)
+        assert "phone" in result
+
+    def test_humanize_driving(self):
+        """Medium CO2 returns driving comparison."""
+        calc = CarbonCalculator(region="US")
+        result = calc.humanize(200.0)
+        assert "driving" in result or "miles" in result
+
+    def test_humanize_ac(self):
+        """Large CO2 returns air conditioning comparison."""
+        calc = CarbonCalculator(region="US")
+        result = calc.humanize(3000.0)
+        assert "air conditioning" in result

--- a/tests/test_carbon_store.py
+++ b/tests/test_carbon_store.py
@@ -1,0 +1,221 @@
+"""Tests for carbon session store."""
+
+import pytest
+
+from warpt.carbon.store import EnergyStore
+from warpt.models.carbon_models import CarbonSession
+
+
+@pytest.fixture
+def tmp_store(tmp_path):
+    """Create a store backed by a temporary directory."""
+    return EnergyStore(base_dir=tmp_path / "sessions")
+
+
+@pytest.fixture
+def sample_session():
+    """Create a sample completed session."""
+    return CarbonSession(
+        id="test-session-001",
+        label="test",
+        start_time=1000.0,
+        end_time=1060.0,
+        duration_s=60.0,
+        energy_kwh=0.001,
+        co2_grams=0.39,
+        cost_usd=0.00012,
+        region="US",
+        platform="linux",
+        sources=["rapl"],
+        metadata={
+            "avg_power_w": 60.0,
+            "peak_power_w": 80.0,
+            "sample_count": 60,
+        },
+        samples=[
+            {
+                "timestamp": 1000.0 + i,
+                "power_watts": 60.0,
+                "cpu_watts": 60.0,
+                "gpu_watts": 0.0,
+            }
+            for i in range(5)
+        ],
+    )
+
+
+class TestEnergyStore:
+    """Tests for JSON file-based session storage."""
+
+    def test_create_and_get_session(self, tmp_store, sample_session):
+        """Create a session and read it back."""
+        tmp_store.create_session(sample_session)
+        loaded = tmp_store.get_session("test-session-001")
+        assert loaded is not None
+        assert loaded.id == "test-session-001"
+        assert loaded.label == "test"
+        assert loaded.energy_kwh == 0.001
+
+    def test_get_nonexistent_session(self, tmp_store):
+        """Return None for missing sessions."""
+        assert tmp_store.get_session("nonexistent") is None
+
+    def test_update_session(self, tmp_store, sample_session):
+        """Update overwrites session data on disk."""
+        tmp_store.create_session(sample_session)
+        sample_session.energy_kwh = 0.002
+        sample_session.co2_grams = 0.78
+        tmp_store.update_session(sample_session)
+
+        loaded = tmp_store.get_session("test-session-001")
+        assert loaded.energy_kwh == 0.002
+        assert loaded.co2_grams == 0.78
+
+    def test_delete_session(self, tmp_store, sample_session):
+        """Delete removes the session file."""
+        tmp_store.create_session(sample_session)
+        tmp_store.delete_session("test-session-001")
+        assert tmp_store.get_session("test-session-001") is None
+
+    def test_delete_nonexistent_session(self, tmp_store):
+        """Delete of missing session does not raise."""
+        tmp_store.delete_session("nonexistent")
+
+    def test_get_sessions_empty(self, tmp_store):
+        """Empty store returns empty list."""
+        sessions = tmp_store.get_sessions()
+        assert sessions == []
+
+    def test_get_sessions_returns_sorted(self, tmp_store):
+        """Sessions are returned newest-first."""
+        for i in range(3):
+            s = CarbonSession(
+                id=f"session-{i}",
+                label="test",
+                start_time=1000.0 + i * 100,
+            )
+            tmp_store.create_session(s)
+
+        sessions = tmp_store.get_sessions()
+        assert len(sessions) == 3
+        assert sessions[0].id == "session-2"
+        assert sessions[2].id == "session-0"
+
+    def test_get_sessions_with_limit(self, tmp_store):
+        """Limit caps the number of returned sessions."""
+        for i in range(5):
+            s = CarbonSession(
+                id=f"session-{i}",
+                label="test",
+                start_time=1000.0 + i,
+            )
+            tmp_store.create_session(s)
+
+        sessions = tmp_store.get_sessions(limit=2)
+        assert len(sessions) == 2
+
+    def test_get_sessions_with_since(self, tmp_store):
+        """Since filter excludes older sessions."""
+        for i in range(5):
+            s = CarbonSession(
+                id=f"session-{i}",
+                label="test",
+                start_time=1000.0 + i * 100,
+            )
+            tmp_store.create_session(s)
+
+        sessions = tmp_store.get_sessions(since=1250.0)
+        assert len(sessions) == 2
+
+    def test_get_sessions_ignores_malformed_json(self, tmp_store):
+        """Malformed JSON files are silently skipped."""
+        s = CarbonSession(id="good", label="test", start_time=1000.0)
+        tmp_store.create_session(s)
+
+        tmp_store._ensure_dir()
+        bad_path = tmp_store._base_dir / "bad.json"
+        bad_path.write_text("not json")
+
+        sessions = tmp_store.get_sessions()
+        assert len(sessions) == 1
+        assert sessions[0].id == "good"
+
+
+class TestEnergyStoreTotals:
+    """Tests for aggregation / get_totals."""
+
+    def test_totals_empty(self, tmp_store):
+        """Empty store returns zero summary."""
+        summary = tmp_store.get_totals()
+        assert summary.total_sessions == 0
+        assert summary.total_energy_kwh == 0.0
+        assert summary.humanized == "No sessions recorded"
+
+    def test_totals_single_session(self, tmp_store, sample_session):
+        """Single session totals match session values."""
+        tmp_store.create_session(sample_session)
+        summary = tmp_store.get_totals()
+
+        assert summary.total_sessions == 1
+        assert summary.total_energy_kwh == 0.001
+        assert summary.total_co2_grams == 0.39
+        assert summary.total_cost_usd == 0.00012
+        assert summary.avg_power_watts == 60.0
+
+    def test_totals_multiple_sessions(self, tmp_store):
+        """Multiple sessions are aggregated correctly."""
+        for i in range(3):
+            s = CarbonSession(
+                id=f"session-{i}",
+                label="test",
+                start_time=1000.0 + i * 100,
+                end_time=1060.0 + i * 100,
+                duration_s=60.0,
+                energy_kwh=0.001,
+                co2_grams=0.39,
+                cost_usd=0.00012,
+                region="US",
+                metadata={"avg_power_w": 60.0},
+            )
+            tmp_store.create_session(s)
+
+        summary = tmp_store.get_totals()
+        assert summary.total_sessions == 3
+        assert abs(summary.total_energy_kwh - 0.003) < 1e-9
+
+    def test_totals_with_since_filter(self, tmp_store):
+        """Since filter limits aggregation window."""
+        for i in range(3):
+            s = CarbonSession(
+                id=f"session-{i}",
+                label="test",
+                start_time=1000.0 + i * 1000,
+                energy_kwh=0.001,
+                co2_grams=0.39,
+                cost_usd=0.00012,
+                region="US",
+            )
+            tmp_store.create_session(s)
+
+        summary = tmp_store.get_totals(since=1500.0)
+        assert summary.total_sessions == 2
+
+
+class TestCarbonSessionSerialization:
+    """Tests for CarbonSession to_dict / from_dict round-trip."""
+
+    def test_round_trip(self, sample_session):
+        """Serialize and deserialize preserves all fields."""
+        d = sample_session.to_dict()
+        restored = CarbonSession.from_dict(d)
+        assert restored.id == sample_session.id
+        assert restored.energy_kwh == sample_session.energy_kwh
+        assert restored.region == sample_session.region
+        assert len(restored.samples) == len(sample_session.samples)
+
+    def test_to_dict_none_values(self):
+        """None fields serialize as null."""
+        s = CarbonSession(id="test", label="test", start_time=1000.0)
+        d = s.to_dict()
+        assert d["end_time"] is None
+        assert d["energy_kwh"] is None

--- a/tests/test_carbon_tracker.py
+++ b/tests/test_carbon_tracker.py
@@ -1,0 +1,142 @@
+"""Tests for CarbonTracker context manager."""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from warpt.carbon.tracker import CarbonTracker
+from warpt.models.carbon_models import CarbonSession
+from warpt.models.power_models import PowerSnapshot
+
+# PowerMonitor is imported at module level in tracker.py, so patch
+# the name in the tracker module (where it's looked up at runtime).
+_PM_PATH = "warpt.carbon.tracker.PowerMonitor"
+
+
+class TestCarbonTrackerNoop:
+    """Tests for CarbonTracker graceful degradation."""
+
+    @patch(_PM_PATH)
+    def test_noop_when_no_power_sources(self, _mock_pm_cls):
+        """Tracker becomes no-op when initialize() returns False."""
+        mock_monitor = MagicMock()
+        mock_monitor.initialize.return_value = False
+        _mock_pm_cls.return_value = mock_monitor
+
+        with CarbonTracker(label="test") as tracker:
+            assert tracker._noop is True
+            result = 1 + 1
+
+        assert result == 2
+
+    @patch(_PM_PATH, side_effect=ImportError("no backend"))
+    def test_noop_when_import_fails(self, _mock_pm_cls):
+        """Tracker becomes no-op when PowerMonitor raises."""
+        with CarbonTracker(label="test") as tracker:
+            assert tracker._noop is True
+
+
+class TestCarbonTrackerIntegration:
+    """Tests for CarbonTracker with mocked power backend."""
+
+    @patch("warpt.carbon.tracker.EnergyStore")
+    @patch(_PM_PATH)
+    def test_creates_and_finalizes_session(self, mock_pm_cls, mock_store_cls):
+        """Tracker creates a session on enter and finalizes on exit."""
+        mock_monitor = MagicMock()
+        mock_monitor.initialize.return_value = True
+        mock_monitor.get_available_sources.return_value = []
+        mock_pm_cls.return_value = mock_monitor
+
+        snapshot = PowerSnapshot(
+            timestamp=time.time(),
+            total_power_watts=50.0,
+        )
+        mock_monitor.get_snapshot.return_value = snapshot
+
+        mock_store = MagicMock()
+        mock_store_cls.return_value = mock_store
+
+        with CarbonTracker(label="test", interval=0.1):
+            time.sleep(0.3)
+
+        assert mock_store.create_session.called
+        assert mock_store.update_session.called
+
+        final_call = mock_store.update_session.call_args
+        session = final_call[0][0]
+        assert isinstance(session, CarbonSession)
+        assert session.label == "test"
+        assert session.end_time is not None
+        assert session.duration_s is not None
+        assert session.duration_s > 0
+
+    @patch("warpt.carbon.tracker.EnergyStore")
+    @patch(_PM_PATH)
+    def test_samples_collected(self, mock_pm_cls, mock_store_cls):
+        """Tracker collects power samples in background thread."""
+        mock_monitor = MagicMock()
+        mock_monitor.initialize.return_value = True
+        mock_monitor.get_available_sources.return_value = []
+        mock_pm_cls.return_value = mock_monitor
+
+        call_count = 0
+
+        def make_snapshot():
+            nonlocal call_count
+            call_count += 1
+            return PowerSnapshot(
+                timestamp=time.time(),
+                total_power_watts=100.0,
+            )
+
+        mock_monitor.get_snapshot.side_effect = make_snapshot
+        mock_store_cls.return_value = MagicMock()
+
+        with CarbonTracker(label="test", interval=0.05):
+            time.sleep(0.25)
+
+        assert call_count >= 2
+
+    @patch("warpt.carbon.tracker.EnergyStore")
+    @patch(_PM_PATH)
+    def test_zero_power_samples_skipped(self, mock_pm_cls, mock_store_cls):
+        """Samples with None total power are not recorded."""
+        mock_monitor = MagicMock()
+        mock_monitor.initialize.return_value = True
+        mock_monitor.get_available_sources.return_value = []
+        mock_pm_cls.return_value = mock_monitor
+
+        snapshot = PowerSnapshot(
+            timestamp=time.time(),
+            total_power_watts=None,
+        )
+        mock_monitor.get_snapshot.return_value = snapshot
+        mock_store_cls.return_value = MagicMock()
+
+        with CarbonTracker(label="test", interval=0.05) as tracker:
+            time.sleep(0.15)
+
+        assert len(tracker._samples) == 0
+
+    @patch("warpt.carbon.tracker.EnergyStore")
+    @patch(_PM_PATH)
+    def test_exception_in_wrapped_code(self, mock_pm_cls, mock_store_cls):
+        """Tracker finalizes session even if wrapped code raises."""
+        mock_monitor = MagicMock()
+        mock_monitor.initialize.return_value = True
+        mock_monitor.get_available_sources.return_value = []
+        mock_pm_cls.return_value = mock_monitor
+
+        snapshot = PowerSnapshot(timestamp=time.time(), total_power_watts=50.0)
+        mock_monitor.get_snapshot.return_value = snapshot
+
+        mock_store = MagicMock()
+        mock_store_cls.return_value = mock_store
+
+        with pytest.raises(ValueError):
+            with CarbonTracker(label="test", interval=0.1):
+                raise ValueError("boom")
+
+        assert mock_store.update_session.called

--- a/tests/test_framework_detection.py
+++ b/tests/test_framework_detection.py
@@ -1,4 +1,5 @@
 """Test framework detection functionality."""
+
 import builtins
 import sys
 from unittest.mock import MagicMock

--- a/warpt/backends/power/daemon.py
+++ b/warpt/backends/power/daemon.py
@@ -94,7 +94,7 @@ class PowerMonitorDaemon:
 
         if not self._sources:
             self._logger.warning(
-                "No power sources discovered. " "Power monitoring will be unavailable."
+                "No power sources discovered. Power monitoring will be unavailable."
             )
 
     def start(self) -> None:

--- a/warpt/benchmarks/hpl.py
+++ b/warpt/benchmarks/hpl.py
@@ -159,7 +159,9 @@ class HPLBenchmark(Benchmark):
             for i in range(n):
                 self.A[i, i] += n
 
-            self.logger.info(f"Allocated {n}x{n} matrix ({n*n*8/(1024**3):.2f} GB)")
+            self.logger.info(
+                f"Allocated {n}x{n} matrix ({n * n * 8 / (1024**3):.2f} GB)"
+            )
         elif self.execution_mode == "docker":
             # Generate HPL.dat in the current directory or a temp directory
             self.generate_hpl_dat("HPL.dat")

--- a/warpt/carbon/__init__.py
+++ b/warpt/carbon/__init__.py
@@ -1,0 +1,1 @@
+"""Carbon tracking package for energy, CO2, and cost estimation."""

--- a/warpt/carbon/calculator.py
+++ b/warpt/carbon/calculator.py
@@ -1,0 +1,116 @@
+"""Energy, CO2, and cost calculation from power samples."""
+
+from __future__ import annotations
+
+from warpt.carbon.grid_intensity import get_grid_intensity
+
+
+class CarbonCalculator:
+    """Convert power samples into energy, CO2 emissions, and cost.
+
+    Parameters
+    ----------
+    region : str
+        Grid region code for CO2 intensity lookup.
+    """
+
+    def __init__(self, region: str = "US") -> None:
+        self.region = region
+        self.intensity = get_grid_intensity(region)  # gCO2/kWh
+
+    def energy_from_samples(self, samples: list[tuple[float, float]]) -> float:
+        """Compute energy via trapezoidal integration.
+
+        Parameters
+        ----------
+        samples : list[tuple[float, float]]
+            List of (timestamp_seconds, watts) pairs.
+
+        Returns
+        -------
+        float
+            Energy in kilowatt-hours. Returns 0.0 if fewer than 2 samples.
+        """
+        if len(samples) < 2:
+            return 0.0
+
+        energy_joules = 0.0
+        for i in range(1, len(samples)):
+            t0, w0 = samples[i - 1]
+            t1, w1 = samples[i]
+            dt = t1 - t0
+            if dt > 0:
+                # Trapezoidal rule: average of two power readings x time
+                energy_joules += (w0 + w1) / 2.0 * dt
+
+        # Convert joules to kWh: 1 kWh = 3,600,000 J
+        return energy_joules / 3_600_000.0
+
+    def co2_from_energy(self, energy_kwh: float) -> float:
+        """Estimate CO2 emissions from energy consumption.
+
+        Parameters
+        ----------
+        energy_kwh : float
+            Energy in kilowatt-hours.
+
+        Returns
+        -------
+        float
+            CO2 emissions in grams.
+        """
+        return energy_kwh * self.intensity
+
+    def cost_from_energy(self, energy_kwh: float, rate: float = 0.12) -> float:
+        """Estimate electricity cost.
+
+        Parameters
+        ----------
+        energy_kwh : float
+            Energy in kilowatt-hours.
+        rate : float
+            Electricity rate in USD per kWh. Default $0.12 (US avg residential).
+
+        Returns
+        -------
+        float
+            Estimated cost in USD.
+        """
+        return energy_kwh * rate
+
+    def humanize(self, co2_grams: float) -> str:
+        """Create a human-relatable comparison for CO2 emissions.
+
+        Parameters
+        ----------
+        co2_grams : float
+            CO2 emissions in grams.
+
+        Returns
+        -------
+        str
+            A comparison string (e.g. "like charging your phone 2 times").
+        """
+        if co2_grams < 1.0:
+            return "less than breathing for a minute"
+
+        if co2_grams < 50.0:
+            # Average phone charge ≈ 8g CO2
+            charges = co2_grams / 8.0
+            if charges < 1.5:
+                return "like charging your phone once"
+            return f"like charging your phone {charges:.0f} times"
+
+        if co2_grams < 500.0:
+            # Average car emits ~400g CO2/mile
+            miles = co2_grams / 400.0
+            if miles < 0.15:
+                return "like driving a few hundred feet"
+            return f"like driving {miles:.1f} miles"
+
+        # Average AC unit ≈ 1500g CO2/hour
+        hours = co2_grams / 1500.0
+        if hours < 1.0:
+            minutes = hours * 60
+            return f"like {minutes:.0f} minutes of air conditioning"
+        return f"like {hours:.1f} hours of air conditioning"

--- a/warpt/carbon/daemon.py
+++ b/warpt/carbon/daemon.py
@@ -1,0 +1,339 @@
+"""Background daemon for manual energy tracking mode."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import signal
+import threading
+import time
+import uuid
+from pathlib import Path
+
+from warpt.carbon.calculator import CarbonCalculator
+from warpt.carbon.store import EnergyStore
+from warpt.models.carbon_models import CarbonSession
+
+PIDFILE = Path.home() / ".warpt" / "carbon.pid"
+SESSIONFILE = Path.home() / ".warpt" / "carbon.session"
+
+
+def _is_process_alive(pid: int) -> bool:
+    """Check if a process with the given PID is running."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except (OSError, ProcessLookupError):
+        return False
+
+
+def _cleanup_stale_files() -> None:
+    """Remove PID/session files if the tracked process is no longer alive."""
+    if PIDFILE.exists():
+        try:
+            pid = int(PIDFILE.read_text().strip())
+            if not _is_process_alive(pid):
+                PIDFILE.unlink(missing_ok=True)
+                SESSIONFILE.unlink(missing_ok=True)
+        except (ValueError, OSError):
+            PIDFILE.unlink(missing_ok=True)
+            SESSIONFILE.unlink(missing_ok=True)
+
+
+def start_daemon(
+    label: str = "manual",
+    interval: float = 1.0,
+    region: str = "US",
+) -> str:
+    """Fork a background daemon process for energy tracking.
+
+    Parameters
+    ----------
+    label : str
+        Session label.
+    interval : float
+        Sampling interval in seconds.
+    region : str
+        Grid region for CO2 calculation.
+
+    Returns
+    -------
+    str
+        The session ID of the started daemon.
+
+    Raises
+    ------
+    RuntimeError
+        If a daemon is already running.
+    """
+    _cleanup_stale_files()
+
+    if PIDFILE.exists():
+        pid = int(PIDFILE.read_text().strip())
+        if _is_process_alive(pid):
+            raise RuntimeError(
+                f"Carbon daemon already running (PID {pid}). "
+                "Stop it with 'warpt carbon stop'."
+            )
+
+    session_id = str(uuid.uuid4())
+
+    # Ensure .warpt directory exists
+    PIDFILE.parent.mkdir(parents=True, exist_ok=True)
+
+    # Fork to background
+    pid = os.fork()
+    if pid > 0:
+        # Parent process — write PID and session info, then return
+        PIDFILE.write_text(str(pid))
+        SESSIONFILE.write_text(
+            json.dumps({"session_id": session_id, "label": label, "region": region})
+        )
+        return session_id
+
+    # Child process — detach and run daemon main loop
+    os.setsid()
+
+    # Redirect stdio to /dev/null
+    devnull = os.open(os.devnull, os.O_RDWR)
+    os.dup2(devnull, 0)
+    os.dup2(devnull, 1)
+    os.dup2(devnull, 2)
+    os.close(devnull)
+
+    try:
+        _daemon_main(session_id, label, interval, region)
+    except Exception:
+        pass
+    finally:
+        PIDFILE.unlink(missing_ok=True)
+        SESSIONFILE.unlink(missing_ok=True)
+
+    os._exit(0)
+
+
+def stop_daemon() -> CarbonSession | None:
+    """Stop a running daemon and return the finalized session.
+
+    Returns
+    -------
+    CarbonSession | None
+        The finalized session data, or None if no daemon was running.
+    """
+    _cleanup_stale_files()
+
+    if not PIDFILE.exists():
+        return None
+
+    try:
+        pid = int(PIDFILE.read_text().strip())
+    except (ValueError, OSError):
+        PIDFILE.unlink(missing_ok=True)
+        SESSIONFILE.unlink(missing_ok=True)
+        return None
+
+    if not _is_process_alive(pid):
+        PIDFILE.unlink(missing_ok=True)
+        SESSIONFILE.unlink(missing_ok=True)
+        return None
+
+    # Read session info before stopping
+    session_id = None
+    if SESSIONFILE.exists():
+        try:
+            info = json.loads(SESSIONFILE.read_text())
+            session_id = info.get("session_id")
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # Send SIGTERM and wait for graceful shutdown
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except (OSError, ProcessLookupError):
+        pass
+
+    # Wait for process to exit (up to 10s)
+    for _ in range(100):
+        if not _is_process_alive(pid):
+            break
+        time.sleep(0.1)
+
+    # Clean up files
+    PIDFILE.unlink(missing_ok=True)
+    SESSIONFILE.unlink(missing_ok=True)
+
+    # Return the finalized session from the store
+    if session_id:
+        store = EnergyStore()
+        return store.get_session(session_id)
+
+    return None
+
+
+def daemon_status() -> dict | None:
+    """Check daemon status.
+
+    Returns
+    -------
+    dict | None
+        Status info dict, or None if no daemon is running.
+    """
+    _cleanup_stale_files()
+
+    if not PIDFILE.exists():
+        return None
+
+    try:
+        pid = int(PIDFILE.read_text().strip())
+    except (ValueError, OSError):
+        return None
+
+    if not _is_process_alive(pid):
+        PIDFILE.unlink(missing_ok=True)
+        SESSIONFILE.unlink(missing_ok=True)
+        return None
+
+    info: dict = {"pid": pid, "running": True}
+
+    if SESSIONFILE.exists():
+        try:
+            session_info = json.loads(SESSIONFILE.read_text())
+            info["session_id"] = session_info.get("session_id")
+            info["label"] = session_info.get("label", "manual")
+            info["region"] = session_info.get("region", "US")
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    # Try to read the session from the store for live stats
+    if "session_id" in info:
+        store = EnergyStore()
+        session = store.get_session(info["session_id"])
+        if session:
+            info["start_time"] = session.start_time
+            elapsed = time.time() - session.start_time
+            info["elapsed_s"] = round(elapsed, 1)
+            info["sample_count"] = session.metadata.get("sample_count", 0)
+            info["avg_power_w"] = session.metadata.get("avg_power_w", 0.0)
+            info["peak_power_w"] = session.metadata.get("peak_power_w", 0.0)
+
+    return info
+
+
+def _daemon_main(
+    session_id: str,
+    label: str,
+    interval: float,
+    region: str,
+) -> None:
+    """Run the main daemon loop.
+
+    Samples power readings and periodically updates the session file.
+    On SIGTERM, finalizes the session and exits.
+    """
+    from warpt.backends.power.factory import PowerMonitor
+
+    shutdown = threading.Event()
+
+    def _handle_sigterm(_signum, _frame):
+        shutdown.set()
+
+    signal.signal(signal.SIGTERM, _handle_sigterm)
+
+    monitor = PowerMonitor(include_process_attribution=False)
+    if not monitor.initialize():
+        return
+
+    sources = [s.value for s in monitor.get_available_sources()]
+    start_time = time.time()
+    samples: list[tuple[float, float, float, float]] = []
+
+    # Create initial session
+    session = CarbonSession(
+        id=session_id,
+        label=label,
+        start_time=start_time,
+        region=region,
+        platform=platform.system().lower(),
+        sources=sources,
+    )
+    store = EnergyStore()
+    store.create_session(session)
+
+    # Sampling loop
+    update_counter = 0
+    while not shutdown.is_set():
+        try:
+            snapshot = monitor.get_snapshot()
+            total = snapshot.total_power_watts
+            cpu = snapshot.get_cpu_power() or 0.0
+            gpu = snapshot.get_gpu_power()
+            if total is not None and total > 0:
+                samples.append((snapshot.timestamp, total, cpu, gpu))
+        except Exception:
+            pass
+
+        # Periodically update session on disk (every 10 samples)
+        update_counter += 1
+        if update_counter >= 10:
+            _update_session_on_disk(session, samples, store)
+            update_counter = 0
+
+        shutdown.wait(timeout=interval)
+
+    # Final update
+    monitor.cleanup()
+    _finalize_session(session, samples, region, store)
+
+
+def _update_session_on_disk(
+    session: CarbonSession,
+    samples: list[tuple[float, float, float, float]],
+    store: EnergyStore,
+) -> None:
+    """Write intermediate session state to disk."""
+    powers = [w for _, w, _, _ in samples]
+    session.metadata = {
+        "avg_power_w": round(sum(powers) / len(powers), 2) if powers else 0.0,
+        "peak_power_w": round(max(powers), 2) if powers else 0.0,
+        "sample_count": len(samples),
+    }
+    store.update_session(session)
+
+
+def _finalize_session(
+    session: CarbonSession,
+    samples: list[tuple[float, float, float, float]],
+    region: str,
+    store: EnergyStore,
+) -> None:
+    """Calculate final energy/CO2/cost and persist the completed session."""
+    calc = CarbonCalculator(region=region)
+    power_samples = [(t, w) for t, w, _c, _g in samples]
+    energy_kwh = calc.energy_from_samples(power_samples)
+    co2_grams = calc.co2_from_energy(energy_kwh)
+    cost_usd = calc.cost_from_energy(energy_kwh)
+
+    end_time = time.time()
+    powers = [w for _, w, _, _ in samples]
+
+    session.end_time = end_time
+    session.duration_s = end_time - session.start_time
+    session.energy_kwh = energy_kwh
+    session.co2_grams = co2_grams
+    session.cost_usd = cost_usd
+    session.metadata = {
+        "avg_power_w": round(sum(powers) / len(powers), 2) if powers else 0.0,
+        "peak_power_w": round(max(powers), 2) if powers else 0.0,
+        "sample_count": len(samples),
+    }
+    session.samples = [
+        {
+            "timestamp": t,
+            "power_watts": round(w, 2),
+            "cpu_watts": round(c, 2),
+            "gpu_watts": round(g, 2),
+        }
+        for t, w, c, g in samples
+    ]
+    store.update_session(session)

--- a/warpt/carbon/grid_intensity.py
+++ b/warpt/carbon/grid_intensity.py
@@ -1,0 +1,64 @@
+"""Grid carbon intensity data by region.
+
+Values represent grams of CO2 emitted per kilowatt-hour of electricity
+generated (gCO2/kWh). Different regions have different energy mixes
+(coal vs nuclear vs hydro vs renewables), so the same kWh produces
+vastly different amounts of CO2.
+
+Sources: IEA, Ember, electricityMap (2023-2024 averages).
+"""
+
+from __future__ import annotations
+
+# gCO2 per kWh by region
+GRID_INTENSITY: dict[str, float] = {
+    # United States
+    "US": 390,
+    "US-CA": 210,
+    "US-TX": 380,
+    "US-NY": 230,
+    "US-WA": 80,
+    # Europe
+    "EU": 230,
+    "EU-FR": 60,
+    "EU-DE": 350,
+    "EU-NO": 20,
+    # Other regions
+    "UK": 200,
+    "CN": 550,
+    "IN": 700,
+    "JP": 450,
+    "AU": 600,
+    "BR": 75,
+    "CA": 120,
+    # Global fallback
+    "WORLD": 440,
+}
+
+
+def get_grid_intensity(region: str) -> float:
+    """Get gCO2/kWh for a region.
+
+    Parameters
+    ----------
+    region : str
+        Region code (e.g. "US", "EU-FR", "WORLD").
+
+    Returns
+    -------
+    float
+        Grid carbon intensity in gCO2/kWh. Falls back to WORLD average
+        if region is not found.
+    """
+    return GRID_INTENSITY.get(region.upper(), GRID_INTENSITY["WORLD"])
+
+
+def list_regions() -> dict[str, float]:
+    """Return all region to intensity mappings.
+
+    Returns
+    -------
+    dict[str, float]
+        Mapping of region codes to gCO2/kWh values.
+    """
+    return dict(GRID_INTENSITY)

--- a/warpt/carbon/store.py
+++ b/warpt/carbon/store.py
@@ -1,0 +1,186 @@
+"""JSON file-based storage for energy tracking sessions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from warpt.carbon.calculator import CarbonCalculator
+from warpt.models.carbon_models import CarbonSession, CarbonSummary
+
+
+class EnergyStore:
+    """Persist energy tracking sessions as JSON files.
+
+    Each session is stored as a separate JSON file in the sessions directory.
+    Default location: ``~/.warpt/sessions/``.
+
+    Parameters
+    ----------
+    base_dir : Path | None
+        Directory for session files. Defaults to ``~/.warpt/sessions/``.
+    """
+
+    def __init__(self, base_dir: Path | None = None) -> None:
+        self._base_dir = base_dir or (Path.home() / ".warpt" / "sessions")
+
+    def _ensure_dir(self) -> None:
+        """Create the sessions directory if it doesn't exist."""
+        self._base_dir.mkdir(parents=True, exist_ok=True)
+
+    def _session_path(self, session_id: str) -> Path:
+        """Return the file path for a session."""
+        return self._base_dir / f"{session_id}.json"
+
+    def create_session(self, session: CarbonSession) -> None:
+        """Write an initial session JSON file.
+
+        Parameters
+        ----------
+        session : CarbonSession
+            The session to persist (typically with end_time=None).
+        """
+        self._ensure_dir()
+        path = self._session_path(session.id)
+        with open(path, "w") as f:
+            json.dump(session.to_dict(), f, indent=2)
+
+    def update_session(self, session: CarbonSession) -> None:
+        """Overwrite a session JSON file with updated data.
+
+        Parameters
+        ----------
+        session : CarbonSession
+            The session with finalized data.
+        """
+        self._ensure_dir()
+        path = self._session_path(session.id)
+        with open(path, "w") as f:
+            json.dump(session.to_dict(), f, indent=2)
+
+    def get_session(self, session_id: str) -> CarbonSession | None:
+        """Read a single session from disk.
+
+        Parameters
+        ----------
+        session_id : str
+            The session UUID.
+
+        Returns
+        -------
+        CarbonSession | None
+            The session, or None if not found.
+        """
+        path = self._session_path(session_id)
+        if not path.exists():
+            return None
+        with open(path) as f:
+            data: dict[str, Any] = json.load(f)
+        return CarbonSession.from_dict(data)
+
+    def get_sessions(
+        self, limit: int = 50, since: float | None = None
+    ) -> list[CarbonSession]:
+        """List sessions, sorted by start time (newest first).
+
+        Parameters
+        ----------
+        limit : int
+            Maximum number of sessions to return.
+        since : float | None
+            Only include sessions started after this Unix timestamp.
+
+        Returns
+        -------
+        list[CarbonSession]
+            Sessions matching the criteria.
+        """
+        if not self._base_dir.exists():
+            return []
+
+        sessions: list[CarbonSession] = []
+        for path in self._base_dir.glob("*.json"):
+            try:
+                with open(path) as f:
+                    data = json.load(f)
+                session = CarbonSession.from_dict(data)
+                if since is not None and session.start_time < since:
+                    continue
+                sessions.append(session)
+            except (json.JSONDecodeError, KeyError):
+                continue
+
+        sessions.sort(key=lambda s: s.start_time, reverse=True)
+        return sessions[:limit]
+
+    def delete_session(self, session_id: str) -> None:
+        """Delete a session file.
+
+        Parameters
+        ----------
+        session_id : str
+            The session UUID to delete.
+        """
+        path = self._session_path(session_id)
+        if path.exists():
+            path.unlink()
+
+    def get_totals(self, since: float | None = None) -> CarbonSummary:
+        """Aggregate totals across all qualifying sessions.
+
+        Parameters
+        ----------
+        since : float | None
+            Only include sessions started after this Unix timestamp.
+
+        Returns
+        -------
+        CarbonSummary
+            Aggregated summary with totals and averages.
+        """
+        sessions = self.get_sessions(limit=10000, since=since)
+
+        if not sessions:
+            return CarbonSummary(humanized="No sessions recorded")
+
+        total_energy = 0.0
+        total_co2 = 0.0
+        total_cost = 0.0
+        total_duration = 0.0
+        total_power_sum = 0.0
+        power_count = 0
+
+        for s in sessions:
+            total_energy += s.energy_kwh or 0.0
+            total_co2 += s.co2_grams or 0.0
+            total_cost += s.cost_usd or 0.0
+            total_duration += s.duration_s or 0.0
+            avg_w = s.metadata.get("avg_power_w")
+            if avg_w is not None:
+                total_power_sum += avg_w
+                power_count += 1
+
+        # Time span from oldest to newest session
+        oldest = min(s.start_time for s in sessions)
+        newest = max(s.start_time for s in sessions)
+        period_days = max((newest - oldest) / 86400.0, 0.0)
+
+        # If all sessions are from the same moment, use duration as the period
+        if period_days == 0.0 and total_duration > 0:
+            period_days = total_duration / 86400.0
+
+        avg_power = total_power_sum / power_count if power_count > 0 else 0.0
+
+        calc = CarbonCalculator(region=sessions[0].region if sessions else "US")
+        humanized = calc.humanize(total_co2)
+
+        return CarbonSummary(
+            total_sessions=len(sessions),
+            total_energy_kwh=total_energy,
+            total_co2_grams=total_co2,
+            total_cost_usd=total_cost,
+            avg_power_watts=avg_power,
+            period_days=period_days,
+            humanized=humanized,
+        )

--- a/warpt/carbon/tracker.py
+++ b/warpt/carbon/tracker.py
@@ -1,0 +1,176 @@
+"""CarbonTracker context manager for automatic energy tracking."""
+
+from __future__ import annotations
+
+import platform
+import sys
+import threading
+import time
+import uuid
+
+from warpt.backends.power.factory import PowerMonitor
+from warpt.carbon.calculator import CarbonCalculator
+from warpt.carbon.store import EnergyStore
+from warpt.models.carbon_models import CarbonSession
+
+
+class CarbonTracker:
+    """Context manager that samples power in a background thread.
+
+    Wraps existing command logic to automatically track energy, CO2,
+    and cost. If no power sources are available, becomes a silent no-op.
+
+    Parameters
+    ----------
+    label : str
+        Human-readable label for the session (e.g. "warpt stress").
+    interval : float
+        Sampling interval in seconds.
+    region : str
+        Grid region for CO2 calculation.
+
+    Examples
+    --------
+    >>> with CarbonTracker(label="warpt stress"):
+    ...     # run some workload
+    ...     pass
+    """
+
+    def __init__(
+        self,
+        label: str,
+        interval: float = 1.0,
+        region: str = "US",
+    ) -> None:
+        self._label = label
+        self._interval = interval
+        self._region = region
+        self._session_id = str(uuid.uuid4())
+        self._monitor: PowerMonitor | None = None
+        self._running = False
+        self._thread: threading.Thread | None = None
+        self._samples: list[tuple[float, float, float, float]] = []
+        self._sources: list[str] = []
+        self._noop = False
+
+    def __enter__(self) -> CarbonTracker:
+        """Start power sampling in a background thread."""
+        try:
+            self._monitor = PowerMonitor(include_process_attribution=False)
+            if not self._monitor.initialize():
+                self._noop = True
+                return self
+
+            self._sources = [s.value for s in self._monitor.get_available_sources()]
+        except Exception:
+            self._noop = True
+            return self
+
+        # Create initial session record
+        self._session = CarbonSession(
+            id=self._session_id,
+            label=self._label,
+            start_time=time.time(),
+            region=self._region,
+            platform=platform.system().lower(),
+            sources=self._sources,
+        )
+
+        store = EnergyStore()
+        store.create_session(self._session)
+
+        # Start background sampling
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._sample_loop, daemon=True, name="carbon-tracker"
+        )
+        self._thread.start()
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Stop sampling, calculate results, and finalize the session."""
+        if self._noop:
+            return
+
+        # Stop the sampling thread
+        self._running = False
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+
+        # Cleanup monitor
+        if self._monitor is not None:
+            try:
+                self._monitor.cleanup()
+            except Exception:
+                pass
+
+        # Calculate energy/CO2/cost
+        calc = CarbonCalculator(region=self._region)
+        power_samples = [(t, w) for t, w, _c, _g in self._samples]
+        energy_kwh = calc.energy_from_samples(power_samples)
+        co2_grams = calc.co2_from_energy(energy_kwh)
+        cost_usd = calc.cost_from_energy(energy_kwh)
+
+        end_time = time.time()
+        duration_s = end_time - self._session.start_time
+
+        # Compute metadata
+        powers = [w for _, w, _, _ in self._samples]
+        avg_power = sum(powers) / len(powers) if powers else 0.0
+        peak_power = max(powers) if powers else 0.0
+
+        # Build sample dicts for storage
+        sample_dicts = [
+            {
+                "timestamp": t,
+                "power_watts": round(w, 2),
+                "cpu_watts": round(c, 2),
+                "gpu_watts": round(g, 2),
+            }
+            for t, w, c, g in self._samples
+        ]
+
+        # Finalize session
+        self._session.end_time = end_time
+        self._session.duration_s = duration_s
+        self._session.energy_kwh = energy_kwh
+        self._session.co2_grams = co2_grams
+        self._session.cost_usd = cost_usd
+        self._session.metadata = {
+            "avg_power_w": round(avg_power, 2),
+            "peak_power_w": round(peak_power, 2),
+            "sample_count": len(self._samples),
+        }
+        self._session.samples = sample_dicts
+
+        store = EnergyStore()
+        store.update_session(self._session)
+
+        # Print one-line summary to stderr
+        humanized = calc.humanize(co2_grams)
+        print(
+            f"\n[carbon] {duration_s:.1f}s | "
+            f"{avg_power:.1f}W avg | "
+            f"{energy_kwh * 1_000_000:.1f} mWh | "
+            f"{co2_grams:.2f}g CO2 | "
+            f"${cost_usd:.4f} | "
+            f"{humanized}",
+            file=sys.stderr,
+        )
+
+    def _sample_loop(self) -> None:
+        """Continuously sample power readings at the configured interval."""
+        while self._running:
+            try:
+                if self._monitor is None:
+                    break
+                snapshot = self._monitor.get_snapshot()
+                total = snapshot.total_power_watts
+                cpu = snapshot.get_cpu_power() or 0.0
+                gpu = snapshot.get_gpu_power()
+                if total is not None and total > 0:
+                    self._samples.append((snapshot.timestamp, total, cpu, gpu))
+            except Exception:
+                pass
+            time.sleep(self._interval)

--- a/warpt/cli.py
+++ b/warpt/cli.py
@@ -448,8 +448,7 @@ def check():
     type=float,
     default=None,
     help=(
-        "Read ratio for StorageMixedTest (0.0-1.0). "
-        "E.g., 0.7 = 70%% reads, 30%% writes"
+        "Read ratio for StorageMixedTest (0.0-1.0). E.g., 0.7 = 70%% reads, 30%% writes"
     ),
 )
 def stress(
@@ -503,6 +502,52 @@ def stress(
         network_mode=network_mode,
         read_ratio=read_ratio,
     )
+
+
+@warpt.command()
+@click.argument(
+    "subcommand",
+    type=click.Choice(["start", "stop", "status", "history", "summary", "regions"]),
+    required=False,
+)
+@click.option("--label", "-l", default=None, help="Session label")
+@click.option("--region", "-r", default="US", help="Grid region for CO2 calculation")
+@click.option(
+    "--interval", "-i", default=1.0, type=float, help="Sampling interval in seconds"
+)
+@click.option(
+    "--limit", "-n", default=20, type=int, help="Max sessions to show in history"
+)
+@click.option(
+    "--days", "-d", default=30, type=int, help="Time window in days for summary"
+)
+@click.option("--json", "output_json", is_flag=True, help="Output in JSON format")
+def carbon(subcommand, label, region, interval, limit, days, output_json):
+    r"""Track energy consumption, CO2 emissions, and electricity cost.
+
+    \b
+    Examples:
+      warpt carbon                     # Show daemon status
+      warpt carbon start               # Start background tracking
+      warpt carbon stop                # Stop and show results
+      warpt carbon history             # Show recent sessions
+      warpt carbon summary --days 7    # Aggregate last 7 days
+      warpt carbon regions             # List grid regions
+
+    \b
+    Automatic mode:
+      Energy is tracked automatically when running 'warpt stress' or
+      'warpt power -c'. A one-line summary prints at the end.
+
+    \b
+    Manual mode:
+      warpt carbon start --label "my workload" --region EU-DE
+      # ... run your workload ...
+      warpt carbon stop
+    """
+    from warpt.commands.carbon_cmd import run_carbon
+
+    run_carbon(subcommand, label, region, interval, limit, days, output_json)
 
 
 if __name__ == "__main__":

--- a/warpt/commands/carbon_cmd.py
+++ b/warpt/commands/carbon_cmd.py
@@ -1,0 +1,267 @@
+"""Carbon tracking CLI command implementation."""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from datetime import datetime
+
+_SECTION_SEP = "=" * 40
+_HEADING_UNDERLINE = "---"
+
+
+def run_carbon(
+    subcommand: str | None,
+    label: str | None,
+    region: str,
+    interval: float,
+    limit: int,
+    days: int,
+    output_json: bool,
+) -> None:
+    """Dispatch to the appropriate carbon subcommand.
+
+    Parameters
+    ----------
+    subcommand : str | None
+        One of: start, stop, status, history, summary, regions.
+    label : str | None
+        Session label for start command.
+    region : str
+        Grid region code.
+    interval : float
+        Sampling interval for daemon.
+    limit : int
+        Max sessions for history.
+    days : int
+        Time window for summary.
+    output_json : bool
+        Whether to output JSON.
+    """
+    if subcommand is None or subcommand == "status":
+        _show_status(output_json)
+    elif subcommand == "start":
+        _start_tracking(label, interval, region)
+    elif subcommand == "stop":
+        _stop_tracking(output_json)
+    elif subcommand == "history":
+        _show_history(limit, output_json)
+    elif subcommand == "summary":
+        _show_summary(days, output_json)
+    elif subcommand == "regions":
+        _show_regions()
+
+
+def _start_tracking(label: str | None, interval: float, region: str) -> None:
+    """Start the carbon tracking daemon."""
+    from warpt.carbon.daemon import start_daemon
+
+    effective_label = label or "manual"
+    try:
+        session_id = start_daemon(
+            label=effective_label, interval=interval, region=region
+        )
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(_SECTION_SEP)
+    print("  carbon tracking started")
+    print(_SECTION_SEP)
+    print(f"\n  Session:  {session_id[:8]}...")
+    print(f"  Label:    {effective_label}")
+    print(f"  Region:   {region}")
+    print(f"  Interval: {interval}s")
+    print("\n  Stop with: warpt carbon stop")
+
+
+def _stop_tracking(output_json: bool) -> None:
+    """Stop the carbon tracking daemon and display results."""
+    from warpt.carbon.daemon import stop_daemon
+
+    session = stop_daemon()
+    if session is None:
+        print("No carbon tracking daemon is running.")
+        return
+
+    if output_json:
+        print(json.dumps(session.to_dict(), indent=2))
+        return
+
+    from warpt.carbon.calculator import CarbonCalculator
+
+    calc = CarbonCalculator(region=session.region)
+    humanized = calc.humanize(session.co2_grams or 0.0)
+
+    print(_SECTION_SEP)
+    print("  carbon tracking stopped")
+    print(_SECTION_SEP)
+    print(f"\n  Session:  {session.id[:8]}...")
+    print(f"  Label:    {session.label}")
+    print(f"  Duration: {_format_duration(session.duration_s or 0)}")
+    print(f"  Region:   {session.region}")
+    print("\n  [Energy]")
+    print(f"  {_HEADING_UNDERLINE}")
+    energy_mwh = (session.energy_kwh or 0) * 1_000_000
+    print(f"  Energy:   {energy_mwh:.1f} mWh ({session.energy_kwh or 0:.8f} kWh)")
+    avg_w = session.metadata.get("avg_power_w", 0)
+    peak_w = session.metadata.get("peak_power_w", 0)
+    print(f"  Avg Power: {avg_w:.1f} W")
+    print(f"  Peak Power: {peak_w:.1f} W")
+    print(f"  Samples:  {session.metadata.get('sample_count', 0)}")
+    print("\n  [Impact]")
+    print(f"  {_HEADING_UNDERLINE}")
+    print(f"  CO2:      {session.co2_grams or 0:.4f} g")
+    print(f"  Cost:     ${session.cost_usd or 0:.6f}")
+    print(f"  ~ {humanized}")
+
+
+def _show_status(output_json: bool) -> None:
+    """Show the current daemon status."""
+    from warpt.carbon.daemon import daemon_status
+
+    status = daemon_status()
+
+    if output_json:
+        print(json.dumps(status or {"running": False}, indent=2))
+        return
+
+    if status is None:
+        print("No carbon tracking daemon is running.")
+        print("\n  Start with: warpt carbon start")
+        return
+
+    print(_SECTION_SEP)
+    print("  carbon tracking active")
+    print(_SECTION_SEP)
+    print(f"\n  PID:      {status['pid']}")
+    print(f"  Session:  {status.get('session_id', 'unknown')[:8]}...")
+    print(f"  Label:    {status.get('label', 'manual')}")
+    print(f"  Region:   {status.get('region', 'US')}")
+    if "elapsed_s" in status:
+        print(f"  Elapsed:  {_format_duration(status['elapsed_s'])}")
+    if "sample_count" in status:
+        print(f"  Samples:  {status['sample_count']}")
+
+    avg_w = status.get("avg_power_w", 0)
+    peak_w = status.get("peak_power_w", 0)
+    if avg_w > 0:
+        elapsed = status.get("elapsed_s", 0)
+        energy_mwh = (avg_w * elapsed / 3600) * 1000  # W * s -> mWh
+        print("\n  [Power]")
+        print(f"  {_HEADING_UNDERLINE}")
+        print(f"  Avg:      {avg_w:.1f} W")
+        print(f"  Peak:     {peak_w:.1f} W")
+        print(f"  Energy:   {energy_mwh:.1f} mWh")
+
+    print("\n  Stop with: warpt carbon stop")
+
+
+def _show_history(limit: int, output_json: bool) -> None:
+    """Display recent tracking sessions."""
+    from warpt.carbon.store import EnergyStore
+
+    store = EnergyStore()
+    sessions = store.get_sessions(limit=limit)
+
+    if output_json:
+        print(json.dumps([s.to_dict() for s in sessions], indent=2))
+        return
+
+    if not sessions:
+        print("No carbon tracking sessions found.")
+        print("\n  Start tracking with: warpt carbon start")
+        return
+
+    print(_SECTION_SEP)
+    print("  carbon tracking history")
+    print(_SECTION_SEP)
+
+    # Table header
+    print(
+        f"\n  {'Date':<12} {'Label':<16} {'Duration':<10} "
+        f"{'Avg W':>7} {'mWh':>8} {'gCO2':>8} {'Cost':>8}"
+    )
+    print(f"  {_HEADING_UNDERLINE * 3}")
+
+    for s in sessions:
+        dt = datetime.fromtimestamp(s.start_time).strftime("%Y-%m-%d")
+        label = s.label[:15] if len(s.label) > 15 else s.label
+        dur = _format_duration(s.duration_s or 0)
+        avg_w = s.metadata.get("avg_power_w", 0)
+        energy_mwh = (s.energy_kwh or 0) * 1_000_000
+        co2 = s.co2_grams or 0
+        cost = s.cost_usd or 0
+
+        print(
+            f"  {dt:<12} {label:<16} {dur:<10} "
+            f"{avg_w:>7.1f} {energy_mwh:>8.1f} {co2:>8.4f} ${cost:>7.4f}"
+        )
+
+    print(f"\n  Showing {len(sessions)} session(s)")
+
+
+def _show_summary(days: int, output_json: bool) -> None:
+    """Show aggregated summary across sessions."""
+    from warpt.carbon.store import EnergyStore
+
+    since = time.time() - (days * 86400)
+    store = EnergyStore()
+    summary = store.get_totals(since=since)
+
+    if output_json:
+        print(json.dumps(summary.to_dict(), indent=2))
+        return
+
+    print(_SECTION_SEP)
+    print(f"  carbon summary (last {days} days)")
+    print(_SECTION_SEP)
+
+    if summary.total_sessions == 0:
+        print("\n  No sessions recorded in this period.")
+        return
+
+    print(f"\n  Sessions:   {summary.total_sessions}")
+    energy_mwh = summary.total_energy_kwh * 1_000_000
+    print(f"  Energy:     {energy_mwh:.1f} mWh ({summary.total_energy_kwh:.8f} kWh)")
+    print(f"  Avg Power:  {summary.avg_power_watts:.1f} W")
+
+    print("\n  [Impact]")
+    print(f"  {_HEADING_UNDERLINE}")
+    print(f"  CO2:        {summary.total_co2_grams:.4f} g")
+    print(f"  Cost:       ${summary.total_cost_usd:.6f}")
+    print(f"  ~ {summary.humanized}")
+
+
+def _show_regions() -> None:
+    """Display all available grid regions and their carbon intensities."""
+    from warpt.carbon.grid_intensity import list_regions
+
+    regions = list_regions()
+
+    print(_SECTION_SEP)
+    print("  grid carbon intensity by region")
+    print(_SECTION_SEP)
+    print(f"\n  {'Region':<10} {'gCO2/kWh':>10}")
+    print(f"  {_HEADING_UNDERLINE * 3}")
+
+    for region, intensity in sorted(regions.items()):
+        print(f"  {region:<10} {intensity:>10.0f}")
+
+    print("\n  Use --region <code> to set your region.")
+    world = regions.get("WORLD", 440)
+    print(f"  Unknown regions fall back to WORLD ({world} gCO2/kWh).")
+
+
+def _format_duration(seconds: float) -> str:
+    """Format a duration in seconds to a human-readable string."""
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    if seconds < 3600:
+        m = int(seconds // 60)
+        s = seconds % 60
+        return f"{m}m{s:.0f}s"
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    return f"{h}h{m}m"

--- a/warpt/commands/power_cmd.py
+++ b/warpt/commands/power_cmd.py
@@ -60,38 +60,41 @@ def run_power(
         monitor.cleanup()
         return
 
-    # Continuous mode
+    # Continuous mode — wrap in CarbonTracker for energy accounting
+    from warpt.carbon.tracker import CarbonTracker
+
     snapshots: list[PowerSnapshot] = []
     start_time = time.time()
 
-    try:
-        print("Power monitoring started. Press Ctrl+C to stop.")
-        print("-" * 60)
+    with CarbonTracker(label="warpt power"):
+        try:
+            print("Power monitoring started. Press Ctrl+C to stop.")
+            print("-" * 60)
 
-        while True:
-            snapshot = monitor.get_snapshot()
-            snapshots.append(snapshot)
+            while True:
+                snapshot = monitor.get_snapshot()
+                snapshots.append(snapshot)
 
-            if output_format == "json":
-                print(json.dumps(snapshot.to_dict(), indent=2))
-            else:
-                _display_snapshot_compact(snapshot, show_processes, top_n_processes)
+                if output_format == "json":
+                    print(json.dumps(snapshot.to_dict(), indent=2))
+                else:
+                    _display_snapshot_compact(snapshot, show_processes, top_n_processes)
 
-            # Check duration limit
-            if duration_seconds and (time.time() - start_time) >= duration_seconds:
-                break
+                # Check duration limit
+                if duration_seconds and (time.time() - start_time) >= duration_seconds:
+                    break
 
-            time.sleep(interval_seconds)
+                time.sleep(interval_seconds)
 
-    except KeyboardInterrupt:
-        print("\nStopping power monitor...")
+        except KeyboardInterrupt:
+            print("\nStopping power monitor...")
 
-    finally:
-        monitor.cleanup()
+        finally:
+            monitor.cleanup()
 
-        if output_file and snapshots:
-            _write_json_output_list(snapshots, output_file)
-            print(f"\nResults written to: {output_file}")
+            if output_file and snapshots:
+                _write_json_output_list(snapshots, output_file)
+                print(f"\nResults written to: {output_file}")
 
 
 def _display_snapshot(

--- a/warpt/commands/stress_cmd.py
+++ b/warpt/commands/stress_cmd.py
@@ -464,7 +464,14 @@ def run_stress(
         test_config = configs.get(test_cls.__name__, {})
         runner.add_test(test_cls, test_config)
 
-    results = runner.run(duration=cfg_duration, skip_unavailable=True)
+    try:
+        from warpt.carbon.tracker import CarbonTracker
+
+        with CarbonTracker(label="warpt stress"):
+            results = runner.run(duration=cfg_duration, skip_unavailable=True)
+    except KeyboardInterrupt:
+        click.echo("\n\nInterrupted.")
+        sys.exit(130)
 
     # Emit results to multiple outputs
     if outputs:

--- a/warpt/models/carbon_models.py
+++ b/warpt/models/carbon_models.py
@@ -1,0 +1,141 @@
+"""Data models for carbon/energy tracking."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class CarbonSession:
+    """A single energy tracking session.
+
+    Attributes
+    ----------
+    id : str
+        Unique session identifier (UUID).
+    label : str
+        Human-readable label (e.g. "warpt stress", "manual").
+    start_time : float
+        Unix timestamp when the session started.
+    end_time : float | None
+        Unix timestamp when the session ended (None while running).
+    duration_s : float | None
+        Duration in seconds.
+    energy_kwh : float | None
+        Total energy consumed in kilowatt-hours.
+    co2_grams : float | None
+        Estimated CO2 emissions in grams.
+    cost_usd : float | None
+        Estimated electricity cost in USD.
+    region : str
+        Grid region used for CO2 calculation.
+    platform : str
+        Operating system platform.
+    sources : list[str]
+        Power measurement sources used (e.g. ["rapl", "nvml"]).
+    metadata : dict[str, Any]
+        Additional info (avg_power_w, peak_power_w, sample_count, etc.).
+    samples : list[dict[str, Any]]
+        Raw power samples collected during the session.
+    """
+
+    id: str
+    label: str
+    start_time: float
+    end_time: float | None = None
+    duration_s: float | None = None
+    energy_kwh: float | None = None
+    co2_grams: float | None = None
+    cost_usd: float | None = None
+    region: str = "US"
+    platform: str = ""
+    sources: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    samples: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "id": self.id,
+            "label": self.label,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "duration_s": (
+                round(self.duration_s, 2) if self.duration_s is not None else None
+            ),
+            "energy_kwh": (
+                round(self.energy_kwh, 8) if self.energy_kwh is not None else None
+            ),
+            "co2_grams": (
+                round(self.co2_grams, 4) if self.co2_grams is not None else None
+            ),
+            "cost_usd": round(self.cost_usd, 6) if self.cost_usd is not None else None,
+            "region": self.region,
+            "platform": self.platform,
+            "sources": self.sources,
+            "metadata": self.metadata,
+            "samples": self.samples,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CarbonSession:
+        """Create a CarbonSession from a dictionary."""
+        return cls(
+            id=data["id"],
+            label=data["label"],
+            start_time=data["start_time"],
+            end_time=data.get("end_time"),
+            duration_s=data.get("duration_s"),
+            energy_kwh=data.get("energy_kwh"),
+            co2_grams=data.get("co2_grams"),
+            cost_usd=data.get("cost_usd"),
+            region=data.get("region", "US"),
+            platform=data.get("platform", ""),
+            sources=data.get("sources", []),
+            metadata=data.get("metadata", {}),
+            samples=data.get("samples", []),
+        )
+
+
+@dataclass
+class CarbonSummary:
+    """Aggregated summary across multiple sessions.
+
+    Attributes
+    ----------
+    total_sessions : int
+        Number of sessions included.
+    total_energy_kwh : float
+        Total energy consumed across all sessions.
+    total_co2_grams : float
+        Total CO2 emissions across all sessions.
+    total_cost_usd : float
+        Total estimated cost across all sessions.
+    avg_power_watts : float
+        Average power draw across all sessions.
+    period_days : float
+        Time span covered in days.
+    humanized : str
+        Human-relatable comparison string for the CO2 amount.
+    """
+
+    total_sessions: int = 0
+    total_energy_kwh: float = 0.0
+    total_co2_grams: float = 0.0
+    total_cost_usd: float = 0.0
+    avg_power_watts: float = 0.0
+    period_days: float = 0.0
+    humanized: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dictionary."""
+        return {
+            "total_sessions": self.total_sessions,
+            "total_energy_kwh": round(self.total_energy_kwh, 8),
+            "total_co2_grams": round(self.total_co2_grams, 4),
+            "total_cost_usd": round(self.total_cost_usd, 6),
+            "avg_power_watts": round(self.avg_power_watts, 2),
+            "period_days": round(self.period_days, 2),
+            "humanized": self.humanized,
+        }

--- a/warpt/stress/gpu_cfd_simulation.py
+++ b/warpt/stress/gpu_cfd_simulation.py
@@ -90,7 +90,7 @@ class GPUCFDSimulationTest(StressTest):
         if self.device_id < 0 or self.device_id >= torch.cuda.device_count():
             raise ValueError(
                 f"Invalid device_id {self.device_id}. "
-                f"Available devices: 0-{torch.cuda.device_count()-1}"
+                f"Available devices: 0-{torch.cuda.device_count() - 1}"
             )
 
         if self.mesh_size < 10000:
@@ -277,7 +277,7 @@ class GPUCFDSimulationTest(StressTest):
         gb_allocated = bytes_allocated / (1024**3)
 
         self.logger.info(
-            f"Allocated {gb_allocated:.2f} GB in {alloc_time*1000:.1f}ms "
+            f"Allocated {gb_allocated:.2f} GB in {alloc_time * 1000:.1f}ms "
             f"({self.mesh_size:,} cells)"
         )
 

--- a/warpt/stress/gpu_fp64_compute.py
+++ b/warpt/stress/gpu_fp64_compute.py
@@ -89,7 +89,7 @@ class GPUFP64ComputeTest(StressTest):
         if self.device_id < 0 or self.device_id >= torch.cuda.device_count():
             raise ValueError(
                 f"Invalid device_id {self.device_id}. "
-                f"Available devices: 0-{torch.cuda.device_count()-1}"
+                f"Available devices: 0-{torch.cuda.device_count() - 1}"
             )
 
         if self.matrix_size < 512:
@@ -334,12 +334,12 @@ class GPUFP64ComputeTest(StressTest):
         self.logger.info(f"Average FP64 performance: {avg_tflops:.3f} TFLOPS")
         self.logger.info(f"Peak FP64 performance: {peak_tflops:.3f} TFLOPS")
         self.logger.info(
-            f"Iteration time: avg={avg_iter_time*1000:.2f}ms, "
-            f"min={min_iter_time*1000:.2f}ms, max={max_iter_time*1000:.2f}ms"
+            f"Iteration time: avg={avg_iter_time * 1000:.2f}ms, "
+            f"min={min_iter_time * 1000:.2f}ms, max={max_iter_time * 1000:.2f}ms"
         )
         self.logger.info(
-            f"Percentiles: p50={p50_time*1000:.2f}ms, "
-            f"p95={p95_time*1000:.2f}ms, p99={p99_time*1000:.2f}ms"
+            f"Percentiles: p50={p50_time * 1000:.2f}ms, "
+            f"p95={p95_time * 1000:.2f}ms, p99={p99_time * 1000:.2f}ms"
         )
 
         return {

--- a/warpt/stress/ram_workload.py
+++ b/warpt/stress/ram_workload.py
@@ -200,7 +200,7 @@ class RAMWorkloadSimulationTest(StressTest):
             f"Simulating {self.workload_mode} workload at different RAM levels..."
         )
         self.logger.info(f"Operations per level: {self.operations_per_level:,}")
-        percentages = ", ".join(f"{p*100:.0f}%" for p in self.test_ram_percentages)
+        percentages = ", ".join(f"{p * 100:.0f}%" for p in self.test_ram_percentages)
         self.logger.info(f"Testing at: {percentages}")
 
         results = []
@@ -211,7 +211,7 @@ class RAMWorkloadSimulationTest(StressTest):
             results.append(result)
 
             self.logger.info(
-                f"  {pct*100:>3.0f}% RAM: {result['ops_per_sec']:>8.0f} ops/sec, "
+                f"  {pct * 100:>3.0f}% RAM: {result['ops_per_sec']:>8.0f} ops/sec, "
                 f"avg latency: {result['avg_latency_us']:.2f} μs"
             )
 
@@ -230,7 +230,7 @@ class RAMWorkloadSimulationTest(StressTest):
         if recommended_pct:
             recommended_gb = self._available_ram_gb * recommended_pct
             self.logger.info(
-                f"\nRecommendation: Maintain at least {recommended_pct*100:.0f}% "
+                f"\nRecommendation: Maintain at least {recommended_pct * 100:.0f}% "
                 f"RAM ({recommended_gb:.1f} GB) for acceptable performance"
             )
         else:

--- a/warpt/stress/storage_sequential_write.py
+++ b/warpt/stress/storage_sequential_write.py
@@ -325,8 +325,7 @@ class StorageSequentialWriteTest(StressTest):
             steady_state_bandwidth_mbps = 0
 
         self.logger.info(
-            f"Wrote {total_mb:.2f} MB in {elapsed:.2f}s "
-            f"({iteration_count} iterations)"
+            f"Wrote {total_mb:.2f} MB in {elapsed:.2f}s ({iteration_count} iterations)"
         )
         self.logger.info(f"Overall bandwidth: {overall_bandwidth_mbps:.2f} MB/s")
         self.logger.info(


### PR DESCRIPTION
Adds a carbon energy tracking subsystem that measures energy consumption, CO2 emissions, and estimated cost. Tracking runs automatically during stress    
  tests and power monitoring, or manually via warpt carbon start/stop. Sessions are persisted locally with history and summary views. Regional grid         
  intensity data is used for CO2 calculations.                                                                                                              
                  
  Also fixes a macOS deadlock where powermetrics was forking a new subprocess every second, which conflicted with Accelerate BLAS threads during matmul
  tests. The fix uses a single persistent powermetrics process that streams data instead.

  All 40 carbon unit tests and 13/13 available stress tests pass.