### PR TITLE
Formatting gpu compute

### DIFF
--- a/docs/WRITING_TESTS.md
+++ b/docs/WRITING_TESTS.md
@@ -241,13 +241,13 @@ The `TestRegistry` automatically discovers your test. Here's how:
 
 - Place your test in `warpt/stress/`
 - Name the file anything except starting with `_` (those are skipped)
-- Common pattern: `{category}_{what}.py` (e.g., `gpu_compute.py`, `cpu_compute.py`)
+- Common pattern: `{category}_{what}.py` (e.g., `gpu_fp32_compute.py`, `cpu_compute.py`)
 
 ### Class Naming Rules
 
 - Use descriptive class names ending in `Test` (convention, not required)
 - Class name must be unique across all tests
-- Examples: `GPUMatMulTest`, `CPUMatMulTest`, `RAMBandwidthTest`
+- Examples: `GPUFP32ComputeTest`, `CPUMatMulTest`, `RAMBandwidthTest`
 
 ## How Results Flow Through the System
 

--- a/warpt/cli.py
+++ b/warpt/cli.py
@@ -394,7 +394,7 @@ def benchmark(
     "-t",
     "tests",
     multiple=True,
-    help="Run specific test(s) by name (e.g., GPUMatMulTest)",
+    help="Run specific test(s) by name (e.g., GPUFP32ComputeTest)",
 )
 @click.option(
     "--duration",
@@ -498,7 +498,7 @@ def stress(
       warpt stress -c all                  # Run all available tests
       warpt stress -c cpu                  # Run CPU category
       warpt stress -c accelerator          # Run accelerator tests
-      warpt stress -t GPUMatMulTest        # Run specific test
+      warpt stress -t GPUFP32ComputeTest        # Run specific test
       warpt stress -o results.json         # Save to JSON
       warpt stress -o a.json -o b.yaml     # Multiple outputs
       warpt stress --config tests.yaml     # Use config file

--- a/warpt/commands/stress_cmd.py
+++ b/warpt/commands/stress_cmd.py
@@ -6,7 +6,7 @@ CLI Examples:
     warpt stress                         # Run all available tests
     warpt stress -c cpu                  # Run CPU category
     warpt stress -c accelerator          # Run accelerator tests
-    warpt stress -t GPUMatMulTest        # Run specific test
+    warpt stress -t GPUFP32ComputeTest        # Run specific test
     warpt stress -o results.json         # Save to JSON
     warpt stress -o a.json -o b.yaml     # Multiple outputs
     warpt stress --config tests.yaml     # Use config file
@@ -53,7 +53,7 @@ def load_config(config_path: str) -> dict[str, Any]:
           warmup: 10
 
         tests:
-          - name: GPUMatMulTest
+          - name: GPUFP32ComputeTest
             duration: 120
             device_id: 0
 

--- a/warpt/integrate/prompts/integration_guide.md
+++ b/warpt/integrate/prompts/integration_guide.md
@@ -75,7 +75,7 @@ warpt/
 │       └── yourvendor_power.py # Add this for power readings (optional, but recommended)
 ├── stress/
 │   ├── base.py                 # StressTest ABC
-│   ├── gpu_compute.py
+│   ├── gpu_fp32_compute.py
 │   └── yourvendor_compute.py   # Add this to enable stress testing on your hardware
 ├── models/
 │   ├── list_models.py          # GPUInfo (Pydantic) — use extra_metrics

--- a/warpt/models/constants.py
+++ b/warpt/models/constants.py
@@ -73,7 +73,7 @@ VALID_STRESS_TARGETS = ("cpu", "gpu", "ram", "all")
 
 # Names for stress tests
 CPU_STRESS_TEST = "CPU Matrix Multiplication"
-GPU_STRESS_TEST = "GPU Matrix Multiplication"
+GPU_FP32_STRESS_TEST = "GPU FP32 Compute"
 MIXED_PRECISION_TEST = "GPU Mixed Precision Profile"
 GPU_MEMORY_TEST = "GPU Memory Bandwidth"
 MULTI_GPU_SCALING_TEST = "Multi-GPU Scaling"

--- a/warpt/models/profile_models.py
+++ b/warpt/models/profile_models.py
@@ -69,7 +69,7 @@ class Observation(BaseModel):
     timestamp: str = Field(..., description="ISO 8601 timestamp")
     test_name: str = Field(
         ...,
-        description="Test class name (e.g., 'GPUFP32ComputeTest', 'GPUMemoryBandwidthTest')",
+        description="Test class name (e.g., 'GPUFP32ComputeTest')",
     )
     category: HardwareCategory = Field(
         ..., description="Hardware category of the tested device"

--- a/warpt/models/profile_models.py
+++ b/warpt/models/profile_models.py
@@ -69,7 +69,7 @@ class Observation(BaseModel):
     timestamp: str = Field(..., description="ISO 8601 timestamp")
     test_name: str = Field(
         ...,
-        description="Test class name (e.g., 'GPUMatMulTest', 'GPUMemoryBandwidthTest')",
+        description="Test class name (e.g., 'GPUFP32ComputeTest', 'GPUMemoryBandwidthTest')",
     )
     category: HardwareCategory = Field(
         ..., description="Hardware category of the tested device"

--- a/warpt/stress/base.py
+++ b/warpt/stress/base.py
@@ -57,7 +57,7 @@ class StressTest(ABC):
         6. teardown() - Clean up resources after test
 
     Example:
-        >>> class GPUMatMulTest(StressTest):
+        >>> class GPUFP32ComputeTest(StressTest):
         ...     _PARAM_FIELDS = ("device_id", "matrix_size", "burnin_seconds")
         ...
         ...     def __init__(self, device_id: int = 0, matrix_size: int = 4096,
@@ -95,7 +95,7 @@ class StressTest(ABC):
         """Get the human-readable test name for display.
 
         Returns:
-            Pretty-printed test name (e.g., "GPU Matrix Multiplication").
+            Pretty-printed test name (e.g., "GPU FP32 Compute").
         """
         pass
 

--- a/warpt/stress/gpu_fp32_compute.py
+++ b/warpt/stress/gpu_fp32_compute.py
@@ -245,7 +245,7 @@ class GPUFP32ComputeTest(StressTest):
 
         elapsed, iter_count = measure_loop(
             duration=duration,
-            work_fn=lambda: torch.matmul(a, b),
+            work_fn=lambda: torch.matmul(a, b),  # noqa: F821
             sync_fn=torch.cuda.synchronize,
             device=self._device,
         )

--- a/warpt/stress/gpu_fp32_compute.py
+++ b/warpt/stress/gpu_fp32_compute.py
@@ -6,7 +6,7 @@ from typing import Any
 from warpt.backends.base import AcceleratorBackend
 from warpt.models.constants import DEFAULT_BURNIN_SECONDS, GPU_FP32_STRESS_TEST
 from warpt.stress.base import StressTest, TestCategory
-from warpt.stress.utils import calculate_tflops
+from warpt.stress.utils import calculate_tflops, measure_loop
 
 
 class GPUFP32ComputeTest(StressTest):
@@ -243,15 +243,12 @@ class GPUFP32ComputeTest(StressTest):
             device=self._device,
         )
 
-        start_time = time.time()  # TODO: consider CUDA events for GPU-side timing
-        iter_count = 0
-
-        while (time.time() - start_time) < duration:
-            _ = torch.matmul(a, b)
-            torch.cuda.synchronize()
-            iter_count += 1
-
-        elapsed = time.time() - start_time
+        elapsed, iter_count = measure_loop(
+            duration=duration,
+            work_fn=lambda: torch.matmul(a, b),
+            sync_fn=torch.cuda.synchronize,
+            device=self._device,
+        )
 
         # Clean up
         del a, b

--- a/warpt/stress/gpu_fp32_compute.py
+++ b/warpt/stress/gpu_fp32_compute.py
@@ -1,16 +1,16 @@
-"""GPU compute stress tests."""
+"""GPU FP32 compute stress test."""
 
 import time
 from typing import Any
 
 from warpt.backends.base import AcceleratorBackend
-from warpt.models.constants import DEFAULT_BURNIN_SECONDS, GPU_STRESS_TEST
+from warpt.models.constants import DEFAULT_BURNIN_SECONDS, GPU_FP32_STRESS_TEST
 from warpt.stress.base import StressTest, TestCategory
 from warpt.stress.utils import calculate_tflops
 
 
-class GPUMatMulTest(StressTest):
-    """Matrix multiplication stress test for GPU.
+class GPUFP32ComputeTest(StressTest):
+    """FP32 compute stress test for GPU.
 
     Uses PyTorch's matmul to stress GPU compute units. Measures TFLOPS
     throughput using FP32 operations (with optional TF32 acceleration).
@@ -26,7 +26,7 @@ class GPUMatMulTest(StressTest):
         matrix_size: int = 8192,
         allow_tf32: bool = True,
     ):
-        """Initialize GPU matmul test.
+        """Initialize GPU FP32 compute test.
 
         Args:
             device_id: GPU device ID (0, 1, 2, etc.)
@@ -54,11 +54,11 @@ class GPUMatMulTest(StressTest):
 
     def get_name(self) -> str:
         """Return internal test name."""
-        return GPU_STRESS_TEST
+        return GPU_FP32_STRESS_TEST
 
     def get_pretty_name(self) -> str:
         """Return human-readable test name."""
-        return "GPU Matrix Multiplication"
+        return "GPU FP32 Compute"
 
     def get_description(self) -> str:
         """Return one-line description."""
@@ -215,7 +215,7 @@ class GPUMatMulTest(StressTest):
     # -------------------------------------------------------------------------
 
     def execute_test(self, duration: int, iterations: int) -> dict[Any, Any]:
-        """Execute the GPU matrix multiplication test.
+        """Execute the GPU FP32 compute test.
 
         Args:
             duration: Test duration in seconds.
@@ -228,28 +228,33 @@ class GPUMatMulTest(StressTest):
         import torch
 
         torch.cuda.reset_peak_memory_stats(self._device)
-        start_time = time.time()
+
+        # Pre-allocate matrices
+        a = torch.randn(
+            self.matrix_size,
+            self.matrix_size,
+            dtype=torch.float32,
+            device=self._device,
+        )
+        b = torch.randn(
+            self.matrix_size,
+            self.matrix_size,
+            dtype=torch.float32,
+            device=self._device,
+        )
+
+        start_time = time.time()  # TODO: consider CUDA events for GPU-side timing
         iter_count = 0
 
         while (time.time() - start_time) < duration:
-            a = torch.randn(
-                self.matrix_size,
-                self.matrix_size,
-                dtype=torch.float32,
-                device=self._device,
-            )
-            b = torch.randn(
-                self.matrix_size,
-                self.matrix_size,
-                dtype=torch.float32,
-                device=self._device,
-            )
             _ = torch.matmul(a, b)
             torch.cuda.synchronize()
             iter_count += 1
-            del a, b
 
         elapsed = time.time() - start_time
+
+        # Clean up
+        del a, b
 
         # Get memory stats
         memory_used = torch.cuda.max_memory_allocated(self._device) / (1024**3)

--- a/warpt/stress/gpu_fp64_compute.py
+++ b/warpt/stress/gpu_fp64_compute.py
@@ -267,11 +267,11 @@ class GPUFP64ComputeTest(StressTest):
 
         def work():
             nonlocal matmul_count, c
-            c = torch.matmul(a, b)
+            c = torch.matmul(a, b)  # noqa: F821
             matmul_count += 1
             # Prevent compiler optimization by occasionally modifying data
             if matmul_count % 10 == 0:
-                a[0, 0] = c[0, 0]
+                a[0, 0] = c[0, 0]  # noqa: F821
 
         test_elapsed, _ = measure_loop(
             duration=duration,

--- a/warpt/stress/gpu_fp64_compute.py
+++ b/warpt/stress/gpu_fp64_compute.py
@@ -10,6 +10,7 @@ from typing import Any
 from warpt.backends.base import AcceleratorBackend
 from warpt.models.constants import DEFAULT_BURNIN_SECONDS
 from warpt.stress.base import StressTest, TestCategory
+from warpt.stress.utils import measure_loop
 
 
 class GPUFP64ComputeTest(StressTest):
@@ -259,57 +260,25 @@ class GPUFP64ComputeTest(StressTest):
         flops_per_matmul = 2 * (self.matrix_size**3)
 
         # Run test for specified duration
-        matmul_count = 0
-        test_start = time.time()
-        iteration_times = []
-
         self.logger.info("Starting FP64 matrix multiplications...")
 
-        # Check first iteration for extremely slow GPUs
-        first_iter_start = time.perf_counter()
-        try:
+        matmul_count = 0
+        c = None
+
+        def work():
+            nonlocal matmul_count, c
             c = torch.matmul(a, b)
-            torch.cuda.synchronize(self._device)
-        except RuntimeError as e:
-            torch.cuda.empty_cache()
-            raise RuntimeError(
-                f"GPU computation failed: {e}. This may indicate driver issues "
-                f"or insufficient GPU memory."
-            ) from e
-
-        first_iter_time = time.perf_counter() - first_iter_start
-        iteration_times.append(first_iter_time)
-        matmul_count += 1
-
-        # Warn if GPU is extremely slow (gaming GPU with crippled FP64)
-        if first_iter_time > 30.0:
-            self.logger.warning(
-                f"First iteration took {first_iter_time:.1f}s. "
-                f"This GPU likely has severely limited FP64 performance. "
-                f"Consider using a professional/scientific GPU for FP64 workloads."
-            )
-
-        # Continue test
-        while (time.time() - test_start) < duration:
-            iter_start = time.perf_counter()
-
-            try:
-                c = torch.matmul(a, b)
-                torch.cuda.synchronize(self._device)
-            except RuntimeError:
-                self.logger.error(f"GPU computation failed at iteration {matmul_count}")
-                torch.cuda.empty_cache()
-                raise
-
-            iter_elapsed = time.perf_counter() - iter_start
-            iteration_times.append(iter_elapsed)
             matmul_count += 1
-
             # Prevent compiler optimization by occasionally modifying data
             if matmul_count % 10 == 0:
                 a[0, 0] = c[0, 0]
 
-        test_elapsed = time.time() - test_start
+        test_elapsed, _ = measure_loop(
+            duration=duration,
+            work_fn=work,
+            sync_fn=torch.cuda.synchronize,
+            device=self._device,
+        )
 
         # Clean up
         del a, b, c
@@ -319,38 +288,9 @@ class GPUFP64ComputeTest(StressTest):
         total_flops = flops_per_matmul * matmul_count
         avg_tflops = (total_flops / test_elapsed) / 1e12
 
-        if iteration_times:
-            avg_iter_time = sum(iteration_times) / len(iteration_times)
-            min_iter_time = min(iteration_times)
-            max_iter_time = max(iteration_times)
-            peak_tflops = flops_per_matmul / (min_iter_time * 1e12)
-
-            # Calculate percentiles
-            sorted_times = sorted(iteration_times)
-            p50_time = sorted_times[len(sorted_times) // 2]
-            p95_time = sorted_times[int(len(sorted_times) * 0.95)]
-            p99_time = sorted_times[int(len(sorted_times) * 0.99)]
-        else:
-            avg_iter_time = 0
-            min_iter_time = 0
-            max_iter_time = 0
-            peak_tflops = 0
-            p50_time = 0
-            p95_time = 0
-            p99_time = 0
-
         # Logging
         self.logger.info(f"Completed {matmul_count} matrix multiplications")
         self.logger.info(f"Average FP64 performance: {avg_tflops:.3f} TFLOPS")
-        self.logger.info(f"Peak FP64 performance: {peak_tflops:.3f} TFLOPS")
-        self.logger.info(
-            f"Iteration time: avg={avg_iter_time * 1000:.2f}ms, "
-            f"min={min_iter_time * 1000:.2f}ms, max={max_iter_time * 1000:.2f}ms"
-        )
-        self.logger.info(
-            f"Percentiles: p50={p50_time * 1000:.2f}ms, "
-            f"p95={p95_time * 1000:.2f}ms, p99={p99_time * 1000:.2f}ms"
-        )
 
         return {
             "test_name": self.get_name(),
@@ -363,12 +303,12 @@ class GPUFP64ComputeTest(StressTest):
             "matmul_count": matmul_count,
             "total_flops": total_flops,
             "avg_fp64_tflops": avg_tflops,
-            "peak_fp64_tflops": peak_tflops,
+            "peak_fp64_tflops": None,  # TODO: add percentile metrics later
             # Timing metrics
-            "avg_iteration_time_ms": avg_iter_time * 1000,
-            "min_iteration_time_ms": min_iter_time * 1000,
-            "max_iteration_time_ms": max_iter_time * 1000,
-            "p50_iteration_time_ms": p50_time * 1000,
-            "p95_iteration_time_ms": p95_time * 1000,
-            "p99_iteration_time_ms": p99_time * 1000,
+            "avg_iteration_time_ms": None,  # TODO: add percentile metrics later
+            "min_iteration_time_ms": None,
+            "max_iteration_time_ms": None,
+            "p50_iteration_time_ms": None,
+            "p95_iteration_time_ms": None,
+            "p99_iteration_time_ms": None,
         }

--- a/warpt/stress/gpu_precision.py
+++ b/warpt/stress/gpu_precision.py
@@ -243,7 +243,7 @@ class GPUPrecisionTest(StressTest):
             # Benchmark
             elapsed, iterations = measure_loop(
                 duration=test_duration,
-                work_fn=lambda: torch.matmul(a, b),
+                work_fn=lambda: torch.matmul(a, b),  # noqa: F821
                 sync_fn=torch.cuda.synchronize,
                 device=self._device,
             )

--- a/warpt/stress/gpu_precision.py
+++ b/warpt/stress/gpu_precision.py
@@ -213,68 +213,46 @@ class GPUPrecisionTest(StressTest):
         hardware_supported = self._check_hardware_support(dtype)
 
         try:
+            # Allocate once — reuse for warmup and benchmark
+            a = torch.randn(
+                self.matrix_size,
+                self.matrix_size,
+                dtype=dtype,
+                device=self._device,
+            )
+            b = torch.randn(
+                self.matrix_size,
+                self.matrix_size,
+                dtype=dtype,
+                device=self._device,
+            )
+
             # Warmup
             if self.burnin_seconds > 0:
                 start = time.time()
                 while (time.time() - start) < self.burnin_seconds:
-                    a = torch.randn(
-                        self.matrix_size,
-                        self.matrix_size,
-                        dtype=dtype,
-                        device=self._device,
-                    )
-                    b = torch.randn(
-                        self.matrix_size,
-                        self.matrix_size,
-                        dtype=dtype,
-                        device=self._device,
-                    )
                     _ = torch.matmul(a, b)
                     torch.cuda.synchronize()
-                    del a, b
             else:
                 for _ in range(3):
-                    a = torch.randn(
-                        self.matrix_size,
-                        self.matrix_size,
-                        dtype=dtype,
-                        device=self._device,
-                    )
-                    b = torch.randn(
-                        self.matrix_size,
-                        self.matrix_size,
-                        dtype=dtype,
-                        device=self._device,
-                    )
                     _ = torch.matmul(a, b)
                     torch.cuda.synchronize()
-                    del a, b
 
             torch.cuda.empty_cache()
 
             # Benchmark
-            start_time = time.time()
+            start_time = time.time()  # TODO: consider CUDA events for GPU-side timing
             iterations = 0
 
             while (time.time() - start_time) < test_duration:
-                a = torch.randn(
-                    self.matrix_size,
-                    self.matrix_size,
-                    dtype=dtype,
-                    device=self._device,
-                )
-                b = torch.randn(
-                    self.matrix_size,
-                    self.matrix_size,
-                    dtype=dtype,
-                    device=self._device,
-                )
                 _ = torch.matmul(a, b)
                 torch.cuda.synchronize()
                 iterations += 1
-                del a, b
 
             elapsed = time.time() - start_time
+
+            # Clean up
+            del a, b
             torch.cuda.empty_cache()
 
             # Calculate metrics
@@ -357,7 +335,7 @@ class GPUPrecisionTest(StressTest):
             precision_results[precision] = self._test_precision(
                 torch_dtype,
                 precision.value.upper(),
-                f"torch.{torch_dtype}",
+                str(torch_dtype),
                 per_precision_duration,
             )
 

--- a/warpt/stress/gpu_precision.py
+++ b/warpt/stress/gpu_precision.py
@@ -7,7 +7,7 @@ from warpt.backends.base import AcceleratorBackend
 from warpt.models.constants import MIXED_PRECISION_TEST, Precision
 from warpt.models.stress_models import MixedPrecisionResults, PrecisionResult
 from warpt.stress.base import StressTest, TestCategory
-from warpt.stress.utils import calculate_tflops
+from warpt.stress.utils import calculate_tflops, measure_loop
 
 
 class GPUPrecisionTest(StressTest):
@@ -22,7 +22,7 @@ class GPUPrecisionTest(StressTest):
         device_id: int = 0,
         burnin_seconds: int = 0,
         backend: AcceleratorBackend | None = None,
-        matrix_size: int = 2048,
+        matrix_size: int = 4096,
         test_duration: int = 5,
         allow_tf32: bool = True,
         precisions: list[Precision] | None = None,
@@ -33,7 +33,7 @@ class GPUPrecisionTest(StressTest):
             device_id: GPU device ID (0, 1, 2, etc.)
             burnin_seconds: Warmup duration (0 = use 3 iterations).
             backend: GPU backend (NvidiaBackend, AMDBackend, etc.).
-            matrix_size: Size of square matrices (NxN). Default 2048.
+            matrix_size: Size of square matrices (NxN). Default 4096.
             test_duration: Duration per precision test in seconds.
             allow_tf32: Enable TF32 for FP32 operations.
             precisions: Precisions to test. Default: [FP32, FP16, BF16].
@@ -241,15 +241,12 @@ class GPUPrecisionTest(StressTest):
             torch.cuda.empty_cache()
 
             # Benchmark
-            start_time = time.time()  # TODO: consider CUDA events for GPU-side timing
-            iterations = 0
-
-            while (time.time() - start_time) < test_duration:
-                _ = torch.matmul(a, b)
-                torch.cuda.synchronize()
-                iterations += 1
-
-            elapsed = time.time() - start_time
+            elapsed, iterations = measure_loop(
+                duration=test_duration,
+                work_fn=lambda: torch.matmul(a, b),
+                sync_fn=torch.cuda.synchronize,
+                device=self._device,
+            )
 
             # Clean up
             del a, b

--- a/warpt/stress/registry.py
+++ b/warpt/stress/registry.py
@@ -13,7 +13,7 @@ Usage:
     gpu_tests = registry.get_tests_by_category(TestCategory.ACCELERATOR)
 
     # Get a specific test by name
-    test = registry.get_test("GPUMatMulTest")
+    test = registry.get_test("GPUFP32ComputeTest")
 """
 
 import importlib
@@ -192,7 +192,7 @@ class TestRegistry:
         """Get a specific test class by name.
 
         Args:
-            name: The test class name (e.g., "GPUMatMulTest").
+            name: The test class name (e.g., "GPUFP32ComputeTest").
 
         Returns:
             The test class.

--- a/warpt/stress/results.py
+++ b/warpt/stress/results.py
@@ -433,7 +433,8 @@ class TestResults:
             min_ms = result.get("min_iteration_time_ms", 0.0)
             max_ms = result.get("max_iteration_time_ms", 0.0)
             output.write(
-                f"  iteration: avg {avg_ms:.2f}ms, min {min_ms:.2f}ms, max {max_ms:.2f}ms\n"
+                f"  iteration: avg {avg_ms:.2f}ms,"
+                f" min {min_ms:.2f}ms, max {max_ms:.2f}ms\n"
             )
             p50 = result.get("p50_iteration_time_ms", 0.0)
             p95 = result.get("p95_iteration_time_ms", 0.0)

--- a/warpt/stress/results.py
+++ b/warpt/stress/results.py
@@ -6,7 +6,7 @@ Usage:
     from warpt.stress.results import TestResults, OutputFormat
 
     results = TestResults()
-    results.add_result("GPUMatMulTest", test_result_dict)
+    results.add_result("GPUFP32ComputeTest", test_result_dict)
     results.add_result("CPUMatMulTest", test_result_dict)
 
     # Emit to different formats
@@ -46,7 +46,7 @@ class TestResults:
 
     Example:
         >>> results = TestResults()
-        >>> results.add_result("GPUMatMulTest", {"tflops": 12.5, "duration": 30})
+        >>> results.add_result("GPUFP32ComputeTest", {"tflops": 12.5, "duration": 30})
         >>> results.emit("results.json", OutputFormat.JSON)
         >>> results.emit(sys.stdout, OutputFormat.TEXT)
     """
@@ -264,6 +264,21 @@ class TestResults:
         if test_name == "RAMSwapPressureTest":
             self._format_ram_swap_text(output, result)
             return
+        if test_name == "GPUFP32ComputeTest":
+            self._format_gpu_fp32_text(output, result)
+            return
+        if test_name == "GPUFP64ComputeTest":
+            self._format_gpu_fp64_text(output, result)
+            return
+        if test_name == "GPUMemoryBandwidthTest":
+            self._format_gpu_memory_bw_text(output, result)
+            return
+        if test_name == "GPUPrecisionTest":
+            self._format_gpu_precision_text(output, result)
+            return
+        if test_name == "GPUCFDSimulationTest":
+            self._format_gpu_cfd_text(output, result)
+            return
 
         # Highlight key metrics
         key_metrics = ["tflops", "bandwidth_gbps", "duration", "iterations"]
@@ -352,6 +367,229 @@ class TestResults:
         dur = result.get("duration", 0.0)
         warmup = result.get("burnin_seconds", 0)
         output.write(f"  duration: {dur:.0f}s, warmup: {warmup}s\n")
+
+    # -------------------------------------------------------------------------
+    # GPU Shared Helpers
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _format_gpu_device_line(output: StringIO, result: dict[str, Any]) -> None:
+        """Write GPU identity line: 'gpu: NVIDIA RTX 5000 Ada (gpu_0)'."""
+        name = result.get("gpu_name", "unknown")
+        dev = result.get("device_id", 0)
+        dev_str = (
+            dev if isinstance(dev, str) and dev.startswith("gpu_") else f"gpu_{dev}"
+        )
+        output.write(f"  gpu: {name} ({dev_str})\n")
+
+    @staticmethod
+    def _format_duration_line(output: StringIO, result: dict[str, Any]) -> None:
+        """Write duration/warmup line."""
+        dur = result.get("duration", 0.0)
+        warmup = result.get("burnin_seconds", 0)
+        output.write(f"  duration: {dur:.0f}s, warmup: {warmup}s\n")
+
+    # -------------------------------------------------------------------------
+    # GPU Formatters
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _format_gpu_fp32_text(output: StringIO, result: dict[str, Any]) -> None:
+        """Format GPUFP32ComputeTest result."""
+        tflops = result.get("tflops", 0.0)
+        output.write(f"  tflops: {tflops:.2f}\n")
+        output.write("\n")
+
+        TestResults._format_gpu_device_line(output, result)
+
+        size = result.get("matrix_size", 0)
+        precision = result.get("precision", "fp32").upper()
+        tf32 = result.get("tf32_enabled", False)
+        tf32_str = "TF32 enabled" if tf32 else "TF32 disabled"
+        output.write(f"  matrix: {size}x{size} {precision}, {tf32_str}\n")
+
+        mem_used = result.get("memory_used_gb", 0.0)
+        mem_total = result.get("memory_total_gb", 0.0)
+        output.write(f"  memory: {mem_used:.2f} / {mem_total:.2f} GB\n")
+
+        iters = result.get("iterations", 0)
+        output.write(f"  iterations: {iters}\n")
+
+        TestResults._format_duration_line(output, result)
+
+    @staticmethod
+    def _format_gpu_fp64_text(output: StringIO, result: dict[str, Any]) -> None:
+        """Format GPUFP64ComputeTest result."""
+        avg = result.get("avg_fp64_tflops", 0.0)
+        peak = result.get("peak_fp64_tflops", 0.0)
+        output.write(f"  avg tflops: {avg:.2f}\n")
+        output.write(f"  peak tflops: {peak:.2f}\n")
+        output.write("\n")
+
+        avg_ms = result.get("avg_iteration_time_ms", 0.0)
+        min_ms = result.get("min_iteration_time_ms", 0.0)
+        max_ms = result.get("max_iteration_time_ms", 0.0)
+        output.write(
+            f"  iteration: avg {avg_ms:.2f}ms, min {min_ms:.2f}ms, max {max_ms:.2f}ms\n"
+        )
+        p50 = result.get("p50_iteration_time_ms", 0.0)
+        p95 = result.get("p95_iteration_time_ms", 0.0)
+        p99 = result.get("p99_iteration_time_ms", 0.0)
+        output.write(
+            f"  percentiles: p50 {p50:.2f}ms, p95 {p95:.2f}ms, p99 {p99:.2f}ms\n"
+        )
+        output.write("\n")
+
+        TestResults._format_gpu_device_line(output, result)
+
+        size = result.get("matrix_size", 0)
+        output.write(f"  matrix: {size}x{size} FP64\n")
+
+        iters = result.get("matmul_count", 0)
+        output.write(f"  iterations: {iters}\n")
+
+        TestResults._format_duration_line(output, result)
+
+    @staticmethod
+    def _format_gpu_memory_bw_text(output: StringIO, result: dict[str, Any]) -> None:
+        """Format GPUMemoryBandwidthTest result."""
+        d2d = result.get("d2d_bandwidth_gbps", 0.0)
+        d2d_it = result.get("d2d_iterations", 0)
+        h2d = result.get("h2d_bandwidth_gbps")
+        h2d_it = result.get("h2d_iterations")
+        d2h = result.get("d2h_bandwidth_gbps")
+        d2h_it = result.get("d2h_iterations")
+
+        # Find widths for alignment
+        bw_vals = [f"{d2d:.2f}"]
+        if h2d is not None:
+            bw_vals.append(f"{h2d:.2f}")
+        if d2h is not None:
+            bw_vals.append(f"{d2h:.2f}")
+        bw_width = max(len(v) for v in bw_vals)
+
+        output.write(f"  d2d: {d2d:>{bw_width}.2f} GB/s  ({d2d_it} iters)\n")
+        if h2d is not None:
+            output.write(f"  h2d: {h2d:>{bw_width}.2f} GB/s   ({h2d_it} iters)\n")
+        if d2h is not None:
+            output.write(f"  d2h: {d2h:>{bw_width}.2f} GB/s   ({d2h_it} iters)\n")
+        output.write("\n")
+
+        TestResults._format_gpu_device_line(output, result)
+
+        data_sz = result.get("data_size_gb", 0.0)
+        pinned = result.get("used_pinned_memory", False)
+        pinned_str = "yes" if pinned else "no"
+        output.write(f"  data size: {data_sz:.2f} GB, pinned memory: {pinned_str}\n")
+
+        TestResults._format_duration_line(output, result)
+
+    @staticmethod
+    def _format_gpu_precision_text(output: StringIO, result: dict[str, Any]) -> None:
+        """Format GPUPrecisionTest result."""
+        fp32 = result.get("fp32", {})
+        fp16 = result.get("fp16")
+        bf16 = result.get("bf16")
+
+        fp32_tflops = fp32.get("tflops", 0.0) if fp32 else 0.0
+
+        # Headline: per-precision TFLOPS with speedup
+        label_w = 4  # "BF16" is widest label
+        if fp32_tflops:
+            output.write(
+                f"  {'FP32':>{label_w}}: {fp32_tflops:>7.2f} TFLOPS (baseline)\n"
+            )
+
+        fp16_speedup = result.get("fp16_speedup")
+        if fp16 and fp16.get("supported") and fp16.get("tflops") is not None:
+            output.write(
+                f"  {'FP16':>{label_w}}: {fp16['tflops']:>7.2f} TFLOPS"
+                f" ({fp16_speedup:.2f}x)\n"
+                if fp16_speedup
+                else f"  {'FP16':>{label_w}}: {fp16['tflops']:>7.2f} TFLOPS\n"
+            )
+
+        bf16_speedup = result.get("bf16_speedup")
+        if bf16 and bf16.get("supported") and bf16.get("tflops") is not None:
+            output.write(
+                f"  {'BF16':>{label_w}}: {bf16['tflops']:>7.2f} TFLOPS"
+                f" ({bf16_speedup:.2f}x)\n"
+                if bf16_speedup
+                else f"  {'BF16':>{label_w}}: {bf16['tflops']:>7.2f} TFLOPS\n"
+            )
+        output.write("\n")
+
+        # Mixed precision readiness
+        mixed_ready = result.get("mixed_precision_ready", False)
+        ready_str = "yes" if mixed_ready else "no"
+        detail = ""
+        if mixed_ready and bf16_speedup:
+            detail = f" (BF16 {bf16_speedup:.2f}x speedup)"
+        output.write(f"  mixed precision ready: {ready_str}{detail}\n")
+
+        tf32 = result.get("tf32_enabled", False)
+        output.write(f"  TF32 enabled: {'yes' if tf32 else 'no'}\n")
+        output.write("\n")
+
+        # Matrix size from FP32 baseline
+        matrix_size = fp32.get("matrix_size", 0) if fp32 else 0
+        if matrix_size:
+            output.write(f"  matrix: {matrix_size}x{matrix_size}\n")
+
+    @staticmethod
+    def _format_gpu_cfd_text(output: StringIO, result: dict[str, Any]) -> None:
+        """Format GPUCFDSimulationTest result."""
+        # Operation summary rows: label, rate, unit, avg, p95
+        rows = []
+
+        solves_sec = result.get("solves_per_sec", 0.0)
+        avg_solver = result.get("avg_solver_time_ms", 0.0)
+        p95_solver = result.get("p95_solver_time_ms", 0.0)
+        rows.append(
+            ("solver", f"{solves_sec:.2f}", "solves/sec", avg_solver, p95_solver)
+        )
+
+        grad_sec = result.get("gradient_ops_per_sec", 0.0)
+        avg_grad = result.get("avg_gradient_time_ms", 0.0)
+        p95_grad = result.get("p95_gradient_time_ms", 0.0)
+        rows.append(("gradients", f"{grad_sec:.2f}", "ops/sec", avg_grad, p95_grad))
+
+        flux_sec = result.get("flux_ops_per_sec", 0.0)
+        avg_flux = result.get("avg_flux_time_ms", 0.0)
+        p95_flux = result.get("p95_flux_time_ms", 0.0)
+        rows.append(("flux", f"{flux_sec:.2f}", "ops/sec", avg_flux, p95_flux))
+
+        # Calculate column widths for alignment
+        label_w = max(len(r[0]) for r in rows)
+        rate_w = max(len(r[1]) for r in rows)
+        unit_w = max(len(r[2]) for r in rows)
+
+        for label, rate, unit, avg_ms, p95_ms in rows:
+            output.write(
+                f"  {label + ':':.<{label_w + 1}} {rate:>{rate_w}} {unit:<{unit_w}}"
+                f"    avg {avg_ms:.2f}ms  p95 {p95_ms:.2f}ms\n"
+            )
+        output.write("\n")
+
+        mem_bw = result.get("memory_bandwidth_gbps")
+        if mem_bw is not None:
+            output.write(f"  memory bandwidth: {mem_bw:.2f} GB/s\n")
+            output.write("\n")
+
+        TestResults._format_gpu_device_line(output, result)
+
+        mesh = result.get("mesh_size", 0)
+        # Format mesh size: 30000000 → "30M"
+        if mesh >= 1_000_000:
+            mesh_str = f"{mesh / 1_000_000:.0f}M"
+        elif mesh >= 1_000:
+            mesh_str = f"{mesh / 1_000:.0f}K"
+        else:
+            mesh_str = str(mesh)
+        solver_iters = result.get("solver_iterations", 0)
+        output.write(f"  mesh: {mesh_str} cells, {solver_iters} solver iterations\n")
+
+        TestResults._format_duration_line(output, result)
 
     @staticmethod
     def _is_two_col_table(value: Any) -> bool:

--- a/warpt/stress/results.py
+++ b/warpt/stress/results.py
@@ -421,24 +421,27 @@ class TestResults:
     def _format_gpu_fp64_text(output: StringIO, result: dict[str, Any]) -> None:
         """Format GPUFP64ComputeTest result."""
         avg = result.get("avg_fp64_tflops", 0.0)
-        peak = result.get("peak_fp64_tflops", 0.0)
         output.write(f"  avg tflops: {avg:.2f}\n")
-        output.write(f"  peak tflops: {peak:.2f}\n")
+
+        peak = result.get("peak_fp64_tflops")
+        if peak is not None:
+            output.write(f"  peak tflops: {peak:.2f}\n")
         output.write("\n")
 
-        avg_ms = result.get("avg_iteration_time_ms", 0.0)
-        min_ms = result.get("min_iteration_time_ms", 0.0)
-        max_ms = result.get("max_iteration_time_ms", 0.0)
-        output.write(
-            f"  iteration: avg {avg_ms:.2f}ms, min {min_ms:.2f}ms, max {max_ms:.2f}ms\n"
-        )
-        p50 = result.get("p50_iteration_time_ms", 0.0)
-        p95 = result.get("p95_iteration_time_ms", 0.0)
-        p99 = result.get("p99_iteration_time_ms", 0.0)
-        output.write(
-            f"  percentiles: p50 {p50:.2f}ms, p95 {p95:.2f}ms, p99 {p99:.2f}ms\n"
-        )
-        output.write("\n")
+        avg_ms = result.get("avg_iteration_time_ms")
+        if avg_ms is not None:
+            min_ms = result.get("min_iteration_time_ms", 0.0)
+            max_ms = result.get("max_iteration_time_ms", 0.0)
+            output.write(
+                f"  iteration: avg {avg_ms:.2f}ms, min {min_ms:.2f}ms, max {max_ms:.2f}ms\n"
+            )
+            p50 = result.get("p50_iteration_time_ms", 0.0)
+            p95 = result.get("p95_iteration_time_ms", 0.0)
+            p99 = result.get("p99_iteration_time_ms", 0.0)
+            output.write(
+                f"  percentiles: p50 {p50:.2f}ms, p95 {p95:.2f}ms, p99 {p99:.2f}ms\n"
+            )
+            output.write("\n")
 
         TestResults._format_gpu_device_line(output, result)
 

--- a/warpt/stress/runner.py
+++ b/warpt/stress/runner.py
@@ -8,7 +8,7 @@ Usage:
     runner = TestRunner()
 
     # Add tests to run
-    runner.add_test(registry.get_test("GPUMatMulTest"))
+    runner.add_test(registry.get_test("GPUFP32ComputeTest"))
     runner.add_tests(registry.get_tests_by_category(TestCategory.CPU))
 
     # Run all tests
@@ -33,7 +33,7 @@ class TestRunner:
 
     Example:
         >>> runner = TestRunner()
-        >>> runner.add_test(GPUMatMulTest)
+        >>> runner.add_test(GPUFP32ComputeTest)
         >>> results = runner.run(duration=30)
         >>> results.emit_stdout()
     """

--- a/warpt/stress/utils.py
+++ b/warpt/stress/utils.py
@@ -49,9 +49,7 @@ def measure_loop(
     import time
 
     use_cuda_events = (
-        device is not None
-        and hasattr(device, "type")
-        and device.type == "cuda"
+        device is not None and hasattr(device, "type") and device.type == "cuda"
     )
 
     if use_cuda_events:

--- a/warpt/stress/utils.py
+++ b/warpt/stress/utils.py
@@ -67,6 +67,7 @@ def measure_loop(
         while (time.time() - loop_start) < duration:
             work_fn()
             iterations += 1
+            torch.cuda.synchronize()  # keep loop in lockstep with GPU
 
         end_event.record()
         torch.cuda.synchronize()

--- a/warpt/stress/utils.py
+++ b/warpt/stress/utils.py
@@ -22,6 +22,72 @@ def calculate_tflops(operations: int, time_seconds: float) -> float:
     return (operations / time_seconds) / 1e12
 
 
+def measure_loop(
+    duration: int,
+    work_fn,
+    sync_fn=None,
+    device=None,
+) -> tuple[float, int]:
+    """Run a timed measurement loop with optional CUDA event timing.
+
+    Primary path: CUDA events for GPU-side timing (when device.type == "cuda").
+    Fallback: time.time() + sync_fn for vendor-agnostic backends.
+
+    Args:
+        duration: Target duration in seconds.
+        work_fn: Zero-arg callable to execute each iteration
+            (e.g., lambda: torch.matmul(a, b)).
+        sync_fn: Optional callable to synchronize the device after the loop.
+            Used in fallback path only (e.g., torch.cuda.synchronize).
+            None = no synchronization.
+        device: torch.device (or similar). If device.type == "cuda",
+            uses CUDA events. Otherwise falls back to time.time().
+
+    Returns:
+        Tuple of (elapsed_seconds, iterations).
+    """
+    import time
+
+    use_cuda_events = (
+        device is not None
+        and hasattr(device, "type")
+        and device.type == "cuda"
+    )
+
+    if use_cuda_events:
+        import torch
+
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+
+        iterations = 0
+        start_event.record()
+        loop_start = time.time()
+
+        while (time.time() - loop_start) < duration:
+            work_fn()
+            iterations += 1
+
+        end_event.record()
+        torch.cuda.synchronize()
+
+        elapsed = start_event.elapsed_time(end_event) / 1000.0
+        return elapsed, iterations
+
+    # Fallback: time.time() + per-iteration sync
+    iterations = 0
+    start_time = time.time()
+
+    while (time.time() - start_time) < duration:
+        work_fn()
+        if sync_fn is not None:
+            sync_fn()
+        iterations += 1
+
+    elapsed = time.time() - start_time
+    return elapsed, iterations
+
+
 def format_results(results: dict) -> str:
     """Format test results for console display.
 

--- a/warpt/utils/logger.py
+++ b/warpt/utils/logger.py
@@ -9,7 +9,7 @@ Usage:
     Logger.configure(level="INFO", timestamps=True)
 
     # Get a logger anywhere in the codebase
-    log = Logger.get("stress.GPUMatMulTest")
+    log = Logger.get("stress.GPUFP32ComputeTest")
     log.info("Starting test...")
 
     # Or log directly
@@ -58,7 +58,7 @@ class Logger:
         >>> Logger.configure(level="INFO")
         >>>
         >>> # Anywhere in the codebase
-        >>> log = Logger.get("stress.GPUMatMulTest")
+        >>> log = Logger.get("stress.GPUFP32ComputeTest")
         >>> log.info("Running test...")
     """
 
@@ -152,7 +152,7 @@ class Logger:
             LoggerNotConfiguredError: If configure() hasn't been called.
 
         Example:
-            >>> log = Logger.get("stress.GPUMatMulTest")
+            >>> log = Logger.get("stress.GPUFP32ComputeTest")
             >>> log.info("Test starting...")
         """
         if not cls._configured:


### PR DESCRIPTION
- cleaned up formatting to show key results first followed by test metadata
- prealloc matrix before starting timer to get accurate reading
- changed time.time() measurement to CUDA event to reduce python overhead with time.time() fallback
- changed ~2000 matrix size to double 